### PR TITLE
Corrected the display of Play Again  button in checkDraw function

### DIFF
--- a/Tic-Tac-Toe Game/scripts/script.js
+++ b/Tic-Tac-Toe Game/scripts/script.js
@@ -52,7 +52,7 @@ function checkDraw() {
         if (isDraw) {
             isGameOver = true;
             document.querySelector("#results").innerHTML = "Match drawn";
-            document.querySelector("#play-again").innerHTML = "inline";
+            document.querySelector("#play-again").style.display = "inline";
         }
     }
 }


### PR DESCRIPTION
# Description

This pull request addresses the issue where the play again button was not displayed correctly in the Tic-Tac-Toe game when a draw occurred. Instead of showing the button, the code mistakenly attempted to update the inner HTML of the button element, resulting in it not being visible to the user.

The fix involves updating the code to correctly handle the display of the play again button upon a draw in the game. The inner HTML of the button element is no longer modified, and instead, its display property is appropriately updated to ensure it is visible to the user when needed.

Fixes:  #272 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/49231ba7-e104-493d-80fd-fa4c20f1c874)