### PR TITLE
Fix delete button functionality

### DIFF
--- a/ToDo JS Extension/scripts/script.js
+++ b/ToDo JS Extension/scripts/script.js
@@ -45,15 +45,23 @@ function showTasks(){
   }
   let newLiTag = "";
   listArray.forEach((element, index) => {
-    newLiTag += `<li>${element}<span class="icon delete-btn"><i class="fas fa-trash"></i></span></li>`;
+    newLiTag += `<li data-index="${index}">${element}<span class="icon delete-btn"><i class="fas fa-trash"></i></span></li>`;
   });
   todoList.innerHTML = newLiTag; //adding new li tag inside ul tag
   inputBox.value = ""; //once task added leave the input field blank
 }
-//event delegation
+// Event delegation for delete button
 todoList.addEventListener("click", function(event) {
-  if (event.target.classList.contains("delete-btn")) {
-    let index = event.target.dataset.index;
+  const target = event.target;
+  // Check if the click event targets the delete button icon directly
+  if (target.classList.contains("fa-trash")) {
+    // If so, retrieve the index of the todo item from its parent <li> element
+    const index = target.closest("li").dataset.index;
+    deleteTask(index);
+  } else if (target.classList.contains("delete-btn")) {
+    // If the click event targets the delete button container (orange square),
+    // retrieve the index of the todo item from the closest parent <li> element
+    const index = target.closest("li").dataset.index;
     deleteTask(index);
   }
 });


### PR DESCRIPTION
# Description

This pull request fixes the issue where clicking on the trash icon next to a todo item does not remove the corresponding todo item from the list. The problem arises due to the incorrect setting of the data-index attribute on the trash icon, preventing proper identification of the todo item to be removed.

Fixes: #273

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/fda8d8e3-72db-4097-8606-972d1b8f9cc3

