### PR TITLE
Fixes #314

### DIFF
--- a/Flappy Bird Game/style.css
+++ b/Flappy Bird Game/style.css
@@ -5,7 +5,7 @@
 	font-family: Arial, Helvetica, sans-serif;
 }
 body{
-    height: 700px;
+    height: 100vh;
     width: 700px
 }
 .background {


### PR DESCRIPTION
# Description

The white space after the game screen and the scrollbars have been removed, thus improving the overall UI of the Flappy Bird game. 

Fixes:  #314 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

Before:

![Screenshot 2024-05-20 002258](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/138088550/1314dd2d-d187-44b3-b873-c3274d7f3b6f)

After:

![Screenshot 2024-05-21 015259](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/138088550/7a80342d-569d-416c-9ade-10816ee4f4ef)