### PR TITLE
Added Next button in Joke Xpress extension

### DIFF
--- a/Jokes Xpress Extension/all_files/index.html
+++ b/Jokes Xpress Extension/all_files/index.html
@@ -9,6 +9,7 @@
 <body>
     <header>JokesXpress</header>
     <p id="JokeElement">Loading...</p>
+    <button id="NextJokeButton">Next Joke</button>
     <script src="script.js"></script>
 </body>
 </html>

--- a/Jokes Xpress Extension/all_files/script.js
+++ b/Jokes Xpress Extension/all_files/script.js
@@ -1,8 +1,22 @@
-fetch('https://v2.jokeapi.dev/joke/Programming,Miscellaneous,Pun,Christmas?blacklistFlags=nsfw&type=single#')
-.then(data => data.json())
-.then(jokedata =>{
-    const joketext = jokedata.joke;
-    const JokeElement = document.getElementById("JokeElement");
+document.addEventListener('DOMContentLoaded', () => {
+    const jokeElement = document.getElementById("JokeElement");
+    const nextJokeButton = document.getElementById("NextJokeButton");
 
-    JokeElement.innerHTML=joketext;
-})
+    function fetchJoke() {
+        fetch('https://v2.jokeapi.dev/joke/Programming,Miscellaneous,Pun,Christmas?blacklistFlags=nsfw&type=single')
+            .then(response => response.json())
+            .then(jokedata => {
+                jokeElement.innerHTML = jokedata.joke;
+            })
+            .catch(error => {
+                console.error('There has been a problem with your fetch operation:', error);
+                jokeElement.innerHTML = "Failed to fetch a joke.";
+            });
+    }
+
+    // Fetch a joke when the page loads
+    fetchJoke();
+
+    // Fetch a new joke when the button is clicked
+    nextJokeButton.addEventListener('click', fetchJoke);
+});

--- a/Jokes Xpress Extension/all_files/style.css
+++ b/Jokes Xpress Extension/all_files/style.css
@@ -1,23 +1,51 @@
-body{
+body {
     background-color: #28282B;
     margin: 0;
     padding: 0;
     width: 300px;
-    height: auto; 
+    height: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
     border: 3px solid whitesmoke;
 }
-header{
+
+header {
     text-align: center;
     font-size: 25px;
     font-family: 'Times New Roman', Times, serif;
     color: whitesmoke;
+    margin-top: 20px;
 }
-p{
+
+p {
     text-align: center;
     font-size: 22px;
     color: white;
     border-radius: 6px;
     border: 1px solid lightblue;
     padding: 10px;
+    margin: 20px 0;
+    width: 80%;
+    word-wrap: break-word;
+}
+
+button {
+    background-color: #4CAF50; /* Green */
+    border: none;
+    color: white;
+    padding: 15px 32px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 10px 2px;
+    cursor: pointer;
+    border-radius: 8px;
+    transition: background-color 0.3s ease;
+}
+
+button:hover {
+    background-color: #45a049;
 }

--- a/Jokes Xpress Extension/djj/Jokes Xpress Extension/Jokes Xpress Extension/all files/index.html
+++ b/Jokes Xpress Extension/djj/Jokes Xpress Extension/Jokes Xpress Extension/all files/index.html
@@ -9,6 +9,7 @@
 <body>
     <header>JokesXpress</header>
     <p id="JokeElement">Loading...</p>
+    <button id="NextJokeButton">Next Joke</button>
     <script src="script.js"></script>
 </body>
 </html>

--- a/Jokes Xpress Extension/djj/Jokes Xpress Extension/Jokes Xpress Extension/all files/script.js
+++ b/Jokes Xpress Extension/djj/Jokes Xpress Extension/Jokes Xpress Extension/all files/script.js
@@ -1,8 +1,22 @@
-fetch('https://v2.jokeapi.dev/joke/Programming,Miscellaneous,Pun,Christmas?blacklistFlags=nsfw&type=single#')
-.then(data => data.json())
-.then(jokedata =>{
-    const joketext = jokedata.joke;
-    const JokeElement = document.getElementById("JokeElement");
+document.addEventListener('DOMContentLoaded', () => {
+    const jokeElement = document.getElementById("JokeElement");
+    const nextJokeButton = document.getElementById("NextJokeButton");
 
-    JokeElement.innerHTML=joketext;
-})
+    function fetchJoke() {
+        fetch('https://v2.jokeapi.dev/joke/Programming,Miscellaneous,Pun,Christmas?blacklistFlags=nsfw&type=single')
+            .then(response => response.json())
+            .then(jokedata => {
+                jokeElement.innerHTML = jokedata.joke;
+            })
+            .catch(error => {
+                console.error('There has been a problem with your fetch operation:', error);
+                jokeElement.innerHTML = "Failed to fetch a joke.";
+            });
+    }
+
+    // Fetch a joke when the page loads
+    fetchJoke();
+
+    // Fetch a new joke when the button is clicked
+    nextJokeButton.addEventListener('click', fetchJoke);
+});

--- a/Jokes Xpress Extension/djj/Jokes Xpress Extension/Jokes Xpress Extension/all files/style.css
+++ b/Jokes Xpress Extension/djj/Jokes Xpress Extension/Jokes Xpress Extension/all files/style.css
@@ -1,23 +1,51 @@
-body{
+body {
     background-color: #28282B;
     margin: 0;
     padding: 0;
     width: 300px;
-    height: auto; 
+    height: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
     border: 3px solid whitesmoke;
 }
-header{
+
+header {
     text-align: center;
     font-size: 25px;
     font-family: 'Times New Roman', Times, serif;
     color: whitesmoke;
+    margin-top: 20px;
 }
-p{
+
+p {
     text-align: center;
     font-size: 22px;
     color: white;
     border-radius: 6px;
     border: 1px solid lightblue;
     padding: 10px;
+    margin: 20px 0;
+    width: 80%;
+    word-wrap: break-word;
+}
+
+button {
+    background-color: #4CAF50; /* Green */
+    border: none;
+    color: white;
+    padding: 15px 32px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 10px 2px;
+    cursor: pointer;
+    border-radius: 8px;
+    transition: background-color 0.3s ease;
+}
+
+button:hover {
+    background-color: #45a049;
 }


### PR DESCRIPTION
# Description

This pull request includes the addition of a "Next" button to the Joke Express extension, allowing users to fetch and display new jokes without refreshing the page. This enhancement addresses the issue where users could only see one joke at a time, improving the overall user experience.

Fixes:  #355

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/ded4c627-3ec7-4e01-b8d1-63e84b2bfacc)
