### PR TITLE
	modified:   Tic-Tac-Toe Game so that even it get's drawn there is option to play again.

### DIFF
--- a/Tic-Tac-Toe Game/scripts/script.js
+++ b/Tic-Tac-Toe Game/scripts/script.js
@@ -52,7 +52,7 @@ function checkDraw() {
         if (isDraw) {
             isGameOver = true;
             document.querySelector("#results").innerHTML = "Match drawn";
-            document.querySelector("#play-again").innerHTML = "inline";
+            document.querySelector("#play-again").style.display = "inline";
         }
     }
 }


### PR DESCRIPTION
# Description

I have resolved the issue of play again button not showing when game gets drawn.

Fixes:  #420 

<!---give the issue number you fixed----->



# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![ttt-after](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/96623227/dc8dce43-b1fc-4996-a64c-707a5ad19aef)
![TTT-Before](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/96623227/da480357-1b5a-45aa-bc0a-5a0a340dab84)
