### PR TITLE
Adjusted the height and width of Bill Splitter

### DIFF
--- a/Bill Splitter/src/style.css
+++ b/Bill Splitter/src/style.css
@@ -13,7 +13,7 @@ body {
 }
 
 main {
-    max-width: 700px;
+    width: 700px;
     margin: 0 auto;
     display: flex;
     align-items: center;


### PR DESCRIPTION
# Description

This fix addresses the issue where the Bill Splitter's height and width parameters were not being properly set, resulting in inaccuracies in sizing. The adjustments ensure that the Bill Splitter adheres to the specified height and width parameters. improving the usability and accuracy of the Bill Splitter extension.

Fixes:  #410

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/6e4e7379-e204-4ef0-9122-ef498aad2cad)
