### PR TITLE
Adjusted the height and width of code editor

### DIFF
--- a/Code Editor/src/style.css
+++ b/Code Editor/src/style.css
@@ -12,8 +12,8 @@
 }
 
 body {
-    width: 700px;
-    height: 700px;
+    width: 100%;
+    height: 100%;
     font-family: sans-serif;
     background-image: linear-gradient(45deg,var(--light-blue), var(--blue));
 
@@ -23,9 +23,8 @@ body {
 }
 
 .code-editor {
-    width: 90vw;
-    height: 90vh;
-
+    width: 700px; /* Default width for the extension */
+    height: 600px; /* Default height for the extension */
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     background-color: #fff;

--- a/Code Editor/src/style.css
+++ b/Code Editor/src/style.css
@@ -12,7 +12,8 @@
 }
 
 body {
-    height: 100vh;
+    width: 700px;
+    height: 700px;
     font-family: sans-serif;
     background-image: linear-gradient(45deg,var(--light-blue), var(--blue));
 


### PR DESCRIPTION
# Description

This fix addresses the issue where the code editor's height and width parameters were not being properly set, resulting in inaccuracies in sizing. The adjustments ensure that the code editor adheres to the specified height and width parameters. improving the usability and accuracy of the code editor extension.

Fixes:  #414

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/ec5b8062-3297-4e03-b365-d1a450dccff0)
