### PR TITLE
Adjusted the height and width Flappy Bird Game

### DIFF
--- a/Flappy Bird Game/style.css
+++ b/Flappy Bird Game/style.css
@@ -5,7 +5,7 @@
 	font-family: Arial, Helvetica, sans-serif;
 }
 body{
-    height: 100vh;
+    height: 700px;
     width: 700px
 }
 .background {


### PR DESCRIPTION
# Description

This fix addresses the issue where the Flappy Bird Game's height and width parameters were not being properly set, resulting in inaccuracies in sizing. The adjustments ensure that the Flappy Bird Game adheres to the specified height and width parameters. improving the usability and accuracy of the Flappy Bird Game extension.

Fixes:  #428

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/38e2e46d-aa18-4797-b894-2de73aaa2788)
