### PR TITLE
Fix for URL Shortener Extension Load Failure Due to Unreadable Manifest File

### DIFF
--- a/URL Shortener/manifest.json
+++ b/URL Shortener/manifest.json
@@ -1,0 +1,19 @@
+{
+    "manifest_version": 3,
+    "name": "QR Reader",
+    "version": "1.0",
+    "description": "Simple QR Reader",
+    "permissions": [
+      "storage"
+    ],
+    "action": {
+      "default_popup": "index.html"
+    },
+    "web_accessible_resources": [
+      {
+        "resources": ["index.html"],
+        "matches": ["<all_urls>"]
+      }
+    ]
+  }
+  


### PR DESCRIPTION
# Description

Resolved issue with the URL Shortener extension failing to load due to an unreadable manifest file. The issue was caused by the manifest file either missing or being unreadable. By ensuring the manifest file exists and is properly formatted, the extension now loads without errors.

Fixes:  #452

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/8cb4c93f-937f-466d-8fa5-4272065e0d84)
