### PR TITLE
World scramble game: Fix CSP Error by Replacing Inline Event Handlers with External JavaScript Event Listeners

### DIFF
--- a/Word Scramble Game/index.html
+++ b/Word Scramble Game/index.html
@@ -15,7 +15,7 @@
 
     <h2>Word Scramble Game</h2>
     <center>
-      <div class="startArea" onclick="start()"><button class="startBtn">Start the Game</button></div>
+      <div class="startArea"><button class="startBtn">Start the Game</button></div>
     </center>
 
     <div class="content">

--- a/Word Scramble Game/scripts/script.js
+++ b/Word Scramble Game/scripts/script.js
@@ -6,13 +6,12 @@ const wordText = document.querySelector(".word"),
     checkBtn = document.querySelector(".check-word"),
     contentBox = document.querySelector(".container .content"),
     startArea = document.querySelector(".startArea"),
+    startBtn = document.querySelector(".startBtn"),
     scoreArea = document.querySelector(".score"),
     modalContent = document.querySelector(".modal-content");
 
 // Get the modal
 var modal = document.getElementById("myModal");
-// Get the button that opens the modal
-var btn = document.getElementById("myBtn");
 // Get the <span> element that closes the modal
 var span = document.getElementsByClassName("close")[0];
 // Get the text of modal
@@ -125,6 +124,7 @@ const checkWord = () => {
 
 refreshBtn.addEventListener("click", initGame);
 checkBtn.addEventListener("click", checkWord);
+startBtn.addEventListener("click", start);
 
 // When the user clicks on <span> (x), close the modal
 span.onclick = function() {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This pull request resolves the Content Security Policy (CSP) error caused by inline event handlers in the Word Scramble Game application. The inline onclick attribute was replaced with external JavaScript event listeners to comply with the CSP directive script-src 'self'. These changes ensure that the game functions correctly without CSP violations.

Fixes:  #469

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/4d91230a-d07f-4383-b07b-57e9d1e6c002)
