### PR TITLE
Add 'Play Again' Button Functionality to Pac-Man Chrome Extension

### DIFF
--- a/Pac Man/popup.html
+++ b/Pac Man/popup.html
@@ -33,6 +33,12 @@
     <div class="grid"></div>
     <h3>Score: <span id="score">0</span></h3>
   </div>
+  <div id="popup" class="popup">
+    <div class="popup-content">
+      <h2 id="popup-message"></h2>
+      <button id="play-again-btn">Play Again</button>
+    </div>
+  </div>
   <script type="module" src="scripts/popup.js" defer></script>
 </body>
 </html>

--- a/Pac Man/scripts/popup.js
+++ b/Pac Man/scripts/popup.js
@@ -8,6 +8,55 @@ document.addEventListener("DOMContentLoaded", () => {
   
   const squares = []
 
+  // Function to show the popup with a message
+  function showPopup(message) {
+    const popup = document.getElementById("popup");
+    const popupMessage = document.getElementById("popup-message");
+    popupMessage.textContent = message;
+    popup.style.display = "block";
+  }
+  
+  // Function to hide the popup
+  function hidePopup() {
+    const popup = document.getElementById("popup");
+    popup.style.display = "none";
+  }
+  
+  // Event listener for Play Again button
+  document.getElementById("play-again-btn").addEventListener("click", resetGame);
+  
+  function resetGame() {
+    // Clear the grid
+    grid.innerHTML = '';
+    squares.length = 0;
+  
+    // Reset score
+    score = 0;
+    scoreDisplay.innerHTML = score;
+  
+    // Recreate the board
+    createBoard();
+  
+    // Reset Pac-Man position
+    pacmanCurrentIndex = 490;
+    squares[pacmanCurrentIndex].classList.add("pac-man");
+  
+    // Reset ghost positions and behaviors
+    ghosts.forEach(ghost => {
+      clearInterval(ghost.timerId);
+      ghost.currentIndex = ghost.startIndex;
+      squares[ghost.currentIndex].classList.add(ghost.className, "ghost");
+      moveGhost(ghost);
+    });
+  
+    // Hide the popup
+    hidePopup();
+  
+    // Add event listener back
+    document.addEventListener("keyup", movePacman);
+  }
+
+
   //create your board
   function createBoard() {
     for (let i = 0; i < layout.length; i++) {
@@ -188,27 +237,23 @@ document.addEventListener("DOMContentLoaded", () => {
     }, ghost.speed)
   }
 
-  //check for a game over
+  // Modify your checkForGameOver and checkForWin functions to show the popup
   function checkForGameOver() {
     if (
       squares[pacmanCurrentIndex].classList.contains("ghost") &&
-      !squares[pacmanCurrentIndex].classList.contains("scared-ghost")) {
-      ghosts.forEach(ghost => clearInterval(ghost.timerId))
-      document.removeEventListener("keyup", movePacman)
-      setTimeout(function () {
-        alert("Game Over")
-      }, 500)
+      !squares[pacmanCurrentIndex].classList.contains("scared-ghost")
+    ) {
+      ghosts.forEach(ghost => clearInterval(ghost.timerId));
+      document.removeEventListener("keyup", movePacman);
+      showPopup("Game Over. Try again!");
     }
   }
-
-  //check for a win - change the winning score to whatever you wish
+  
   function checkForWin() {
     if (score >= 274) {
-      ghosts.forEach(ghost => clearInterval(ghost.timerId))
-      document.removeEventListener("keyup", movePacman)
-      setTimeout(function () {
-        alert("You have WON!")
-      }, 500)
+      ghosts.forEach(ghost => clearInterval(ghost.timerId));
+      document.removeEventListener("keyup", movePacman);
+      showPopup("Congratulations! You have won!");
     }
   }
 })

--- a/Pac Man/styles/styles.css
+++ b/Pac Man/styles/styles.css
@@ -72,3 +72,40 @@ body {
 .scared-ghost {
     background-color: aquamarine;
 }
+
+/* Add this CSS to your styles.css */
+.popup {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+  }
+  
+  .popup-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+  }
+  
+  .popup-content button {
+    padding: 10px 20px;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+  }
+  
+  .popup-content button:hover {
+    background-color: #45a049;
+  }
+  


### PR DESCRIPTION
# Description

This pull request addresses issue #520 by adding a "Play Again" button functionality to the Pac-Man Chrome extension. Now, after a game over or victory, users have the option to restart the game without the need to manually refresh the browser or restart the extension.

Fixes:  #520

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/71da9b70-624c-4bb0-97b0-b94900a8b961)
