### PR TITLE
Implement edit function to update existing todo items

### DIFF
--- a/ToDo JS Extension/scripts/script.js
+++ b/ToDo JS Extension/scripts/script.js
@@ -3,6 +3,7 @@ const addBtn = document.querySelector(".inputField button");
 const todoList = document.querySelector(".todoList");
 const deleteAllBtn = document.querySelector(".footer button");
 
+let editIndex = null;
 
 inputBox.onkeyup = ()=>{
   let userEnteredValue = inputBox.value; //getting user entered value
@@ -23,7 +24,14 @@ addBtn.onclick = ()=>{ //when user click on plus icon button
   }else{
     listArray = JSON.parse(getLocalStorageData);  //transforming json string into a js object
   }
-  listArray.push(userEnteredValue); //pushing or adding new value in array
+  if (editIndex !== null) {
+    // Update the todo item
+    listArray[editIndex] = userEnteredValue;
+    editIndex = null;
+  } else {
+    // Add new todo item
+    listArray.push(userEnteredValue); //pushing or adding new value in array
+  }
   localStorage.setItem("New Todo", JSON.stringify(listArray)); //transforming js object into a json string
   showTasks(); //calling showTask function
   addBtn.classList.remove("active"); //unactive the add button once the task added
@@ -45,7 +53,7 @@ function showTasks(){
   }
   let newLiTag = "";
   listArray.forEach((element, index) => {
-    newLiTag += `<li data-index="${index}">${element}<span class="icon delete-btn"><i class="fas fa-trash"></i></span></li>`;
+    newLiTag += `<li data-index="${index}">${element}<span class="icon delete-btn"><i class="fas fa-trash"></i></span><span class="icon edit-icon"><i class="fas fa-edit"></i></span></li>`;
   });
   todoList.innerHTML = newLiTag; //adding new li tag inside ul tag
   inputBox.value = ""; //once task added leave the input field blank
@@ -64,6 +72,14 @@ todoList.addEventListener("click", function(event) {
     const index = target.closest("li").dataset.index;
     deleteTask(index);
   }
+  // Check if the click event targets the edit button icon directly
+  if (target.classList.contains("fa-edit")) {
+    const index = target.closest("li").dataset.index;
+    editTask(index);
+  } else if (target.classList.contains("edit-btn")) {
+    const index = target.closest("li").dataset.index;
+    editTask(index);
+  }
 });
 // delete task function
 function deleteTask(index){
@@ -72,6 +88,15 @@ function deleteTask(index){
   listArray.splice(index, 1); //delete or remove the li
   localStorage.setItem("New Todo", JSON.stringify(listArray));
   showTasks(); //call the showTasks function
+}
+
+// edit task function
+function editTask(index) {
+  let getLocalStorageData = localStorage.getItem("New Todo");
+  listArray = JSON.parse(getLocalStorageData);
+  inputBox.value = listArray[index]; // populate input field with the todo text
+  editIndex = index; // set edit index
+  addBtn.classList.add("active"); // activate the add button
 }
 
 // delete all tasks function

--- a/ToDo JS Extension/src/style.css
+++ b/ToDo JS Extension/src/style.css
@@ -100,8 +100,15 @@ body{
   cursor: pointer;
   transition: all 0.2s ease;
 }
-.todoList li:hover .icon{
-  right: 0px;
+.todoList li .delete-btn {
+  right: 0;
+  background: #e74c3c;
+  border-radius: 0 3px 3px 0;
+}
+.todoList li .edit-icon {
+  right: 50px;
+  background: #f39c12;
+  border-radius: 3px 0 0 3px;
 }
 .wrapper .footer{
   display: flex;


### PR DESCRIPTION
# Description

This pull request introduces the ability to edit existing todo items in the application. Users can now click an edit button next to each todo item, which populates the input field with the item's text for editing. Once edited, the item can be updated by clicking the add button, which now handles both adding and editing items.

Fixes:  #558

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/2bf597f6-f627-4b7e-abbb-c34e864f6536)