### PR TITLE
Added Next button in Dad Jokes extension

### DIFF
--- a/Dad Jokes/popup.css
+++ b/Dad Jokes/popup.css
@@ -3,7 +3,33 @@ body {
     height: 300px;
     background-color: aliceblue;
     display: flex;
+    flex-direction: column;
     justify-content: center;
+}
+header {
+    text-align: center;
+    font-size: 25px;
+    font-family: 'Times New Roman', Times, serif;
+    color: rgb(222, 6, 6);
+    margin-top: 20px;
+}
+button {
+    background-color: #4CAF50;
+    border: none;
+    color: white;
+    padding: 10px 20px;
+    text-align: center;
+    
+    display: inline-block;
+    font-size: 16px;
+    margin: 10px 2px;
+    cursor: pointer;
+    border-radius: 10px;
+    transition: background-color 0.3s ease;
+}
+
+button:hover {
+    background-color: #45a049;
 }
 
 p {

--- a/Dad Jokes/popup.html
+++ b/Dad Jokes/popup.html
@@ -7,7 +7,9 @@
     <link rel="stylesheet" href="popup.css">
 </head>
 <body>
+    <header>Dad Jokes</header>
     <p id="jokeElement">Loading...</p>
+    <button id="NextJokeButton">Next Joke</button>
     <script src="popup.js"></script>
 </body>
 </html>

--- a/Dad Jokes/popup.js
+++ b/Dad Jokes/popup.js
@@ -1,8 +1,22 @@
-fetch('https://icanhazdadjoke.com/slack')
-    .then(data => data.json())
-    .then(jokeData => {
-        const jokeText = jokeData.attachments[0].text;
-        const jokeElement = document.getElementById('jokeElement');
 
-        jokeElement.innerHTML = jokeText;
-    })
+    document.addEventListener('DOMContentLoaded', () => {
+        const jokeElement = document.getElementById("jokeElement");
+        const nextJokeButton = document.getElementById("NextJokeButton");
+        function fetchJoke() {
+        fetch('https://icanhazdadjoke.com/slack')
+            .then(data => data.json())
+            .then(jokedata => {
+                jokeElement.innerHTML = jokedata.attachments[0].text;;
+            })
+            .catch(error => {
+                console.error('There has been a problem with your fetch operation:', error);
+                jokeElement.innerHTML = "Failed to fetch a joke.";
+            });
+    }
+
+    // Fetch a joke when the page loads
+    fetchJoke();
+
+    // Fetch a new joke when the button is clicked
+    nextJokeButton.addEventListener('click', fetchJoke);
+});


### PR DESCRIPTION
# Description

This pull request includes the addition of a "Next" button to the Joke Express extension, allowing users to fetch and display new jokes without refreshing the page. This enhancement addresses the issue where users could only see one joke at a time, improving the overall user experience.

Fixes: https://github.com/Sulagna-Dutta-Roy/GGExtensions/issues/892

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/66067507/9b83e534-d16f-4fae-9e6f-f48648ba55d0