### PR TITLE
Added content setting extension

### DIFF
--- a/Content Setting/manifest.json
+++ b/Content Setting/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Content settings",
+  "version": "0.3",
+  "description": "This extension leverages chrome.contentSettings to reveal and manage the settings associated with a specific webpage directly within the extension's popup interface.",
+  "permissions": [
+    "contentSettings",
+    "activeTab"
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "manifest_version": 3
+}

--- a/Content Setting/popup.css
+++ b/Content Setting/popup.css
@@ -1,0 +1,56 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  padding: 0;
+  background-color: #f4f4f4;
+}
+
+fieldset {
+  border: 1px solid #ccc;
+  width: 300px;
+  border-radius: 5px;
+  padding: 15px;
+  background-color: #fff;
+}
+
+legend {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 10px;
+  color: #333;
+  /* Text color for the legend */
+}
+
+dl {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+dt {
+  width: 45%;
+  margin-bottom: 10px;
+}
+
+dd {
+  width: 50%;
+  margin-bottom: 10px;
+}
+
+label {
+  font-weight: bold;
+}
+
+select {
+  width: 100%;
+  padding: 5px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background-color: #f9f9f9;
+  /* Background color for the select box */
+  color: #333;
+  font-size: 14px;
+}

--- a/Content Setting/popup.html
+++ b/Content Setting/popup.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Content setting</title>
+  <link rel="stylesheet" href="popup.css">
+  <script src="popup.js"></script>
+</head>
+
+<body>
+  <fieldset>
+    <dl>
+      <dt><label for="cookies">Cookies: </label></dt>
+      <dd>
+        <select id="cookies" disabled>
+          <option value="allow">Allow</option>
+          <option value="session_only">Session only</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt><label for="images">Images: </label></dt>
+      <dd>
+        <select id="images" disabled>
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+
+      <dt><label for="javascript">Javascript: </label></dt>
+      <dd>
+        <select id="javascript" disabled>
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt><label for="location">Location: </label></dt>
+      <dd>
+        <select id="location" disabled>
+          <option value="allow">Allow</option>
+          <option value="ask">Ask</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt><label for="plugins">Plugins: </label></dt>
+      <dd>
+        <select id="plugins" disabled>
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt><label for="popups">Pop-ups: </label></dt>
+      <dd>
+        <select id="popups" disabled>
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt><label for="notifications">Notifications: </label></dt>
+      <dd>
+        <select id="notifications" disabled>
+          <option value="allow">Allow</option>
+          <option value="ask">Ask</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt><label for="microphone">Microphone: </label></dt>
+      <dd>
+        <select id="microphone" disabled>
+          <option value="allow">Allow</option>
+          <option value="ask">Ask</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt><label for="camera">Camera: </label></dt>
+      <dd>
+        <select id="camera" disabled>
+          <option value="allow">Allow</option>
+          <option value="ask">Ask</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt>
+        <label for="unsandboxedPlugins">Unsandboxed plugin access: </label>
+      </dt>
+      <dd>
+        <select id="unsandboxedPlugins" disabled>
+          <option value="allow">Allow</option>
+          <option value="ask">Ask</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+      <dt><label for="automaticDownloads">Automatic Downloads: </label></dt>
+      <dd>
+        <select id="automaticDownloads" disabled>
+          <option value="allow">Allow</option>
+          <option value="ask">Ask</option>
+          <option value="block">Block</option>
+        </select>
+      </dd>
+    </dl>
+  </fieldset>
+</body>
+
+</html>

--- a/Content Setting/popup.js
+++ b/Content Setting/popup.js
@@ -1,0 +1,51 @@
+let incognito;
+let url;
+
+function settingChanged() {
+  let type = this.id;
+  let setting = this.value;
+  let pattern = /^file:/.test(url) ? url : url.replace(/\/[^/]*?$/, '/*');
+  console.log(type + ' setting for ' + pattern + ': ' + setting);
+  chrome.contentSettings[type].set({
+    primaryPattern: pattern,
+    setting: setting,
+    scope: incognito ? 'incognito_session_only' : 'regular'
+  });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    let current = tabs[0];
+    incognito = current.incognito;
+    url = current.url;
+    let types = [
+      'cookies',
+      'images',
+      'javascript',
+      'location',
+      'popups',
+      'notifications',
+      'microphone',
+      'camera',
+      'automaticDownloads'
+    ];
+    types.forEach(function (type) {
+      chrome.contentSettings[type] &&
+        chrome.contentSettings[type].get(
+          {
+            primaryUrl: url,
+            incognito: incognito
+          },
+          function (details) {
+            document.getElementById(type).disabled = false;
+            document.getElementById(type).value = details.setting;
+          }
+        );
+    });
+  });
+
+  let selects = document.querySelectorAll('select');
+  for (let i = 0; i < selects.length; i++) {
+    selects[i].addEventListener('change', settingChanged);
+  }
+});


### PR DESCRIPTION
# Description

This pull request adds a content setting extension to the project.
Content settings are crucial for users to tailor their experience according to their preferences and needs. This extension enhances the user experience by allowing them to control various aspects of content display.

Fixes:  #930

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109781385/dbc94232-d9d7-4807-8610-b514dcacd907


