### PR TITLE
added figma extension

### DIFF
--- a/Figma/manifest.json
+++ b/Figma/manifest.json
@@ -1,0 +1,18 @@
+{
+    "manifest_version": 3,
+    "name": "Figma Extension",
+    "version": "1.0",
+    "description": "Navigate to the provided Figma link quickly and easily.",
+    "action": {
+      "default_popup": "welcome.html",
+      "default_icon": {
+        "16": "icon16.png",
+        "48": "icon48.png",
+        "128": "icon128.png"
+      }
+    },
+    "permissions": [
+      "activeTab"
+    ]
+  }
+  

--- a/Figma/popup.html
+++ b/Figma/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Figma Extension</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Figma Extension</h1>
+    <p>Click the button below to navigate to the provided Figma link.</p>
+    <button id="figma-link">Go to Figma</button>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/Figma/popup.js
+++ b/Figma/popup.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const figmaLink = document.getElementById('figma-link');
+    figmaLink.addEventListener('click', function() {
+      chrome.tabs.create({ url: "https://www.figma.com/files/team/1271522887898539493/recents-and-sharing/recently-viewed?fuid=1271522886187338242" });
+    });
+  });
+  

--- a/Figma/styles.css
+++ b/Figma/styles.css
@@ -1,0 +1,42 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    background-color: #f3f3f3;
+    color: #333;
+  }
+  
+  .container {
+    text-align: center;
+  }
+  
+  .typewriter {
+    font-size: 24px;
+    border-right: 2px solid;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  
+  #start-figma-extension {
+    margin-top: 20px;
+    padding: 10px 20px;
+    font-size: 16px;
+    background-color: #fff;
+    color: #333;
+    border: none;
+    cursor: pointer;
+  }
+  
+  #figma-link {
+    display: block;
+    margin-top: 20px;
+    padding: 10px 20px;
+    background-color: #fff;
+    color: #333;
+    text-decoration: none;
+  }
+  

--- a/Figma/welcome.html
+++ b/Figma/welcome.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <div id="welcome-text" class="typewriter"></div>
+    <button id="start-figma-extension" style="display: none;">Start Figma Extension</button>
+  </div>
+  <script src="welcome.js"></script>
+</body>
+</html>

--- a/Figma/welcome.js
+++ b/Figma/welcome.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const welcomeText = "Welcome to the Figma Extension! Enhance your design experience with Figma.";
+    const welcomeElement = document.getElementById('welcome-text');
+    const startFigmaExtensionButton = document.getElementById('start-figma-extension');
+    let i = 0;
+  
+    function typeWriter() {
+      if (i < welcomeText.length) {
+        welcomeElement.innerHTML += welcomeText.charAt(i);
+        i++;
+        setTimeout(typeWriter, 100);
+      } else {
+        startFigmaExtensionButton.style.display = 'block';
+      }
+    }
+  
+    typeWriter();
+  
+    startFigmaExtensionButton.addEventListener('click', function() {
+      chrome.action.setPopup({ popup: 'popup.html' });
+      window.location.href = 'popup.html';
+    });
+  });
+  


### PR DESCRIPTION
# Description

This pull request introduces a new Chrome extension named "Figma Extension" that provides users with quick access to a specific Figma project. The extension includes a welcome page with a typewriter effect that greets users and invites them to explore the Figma project. Upon clicking the button, users are directed to the specified Figma project link.



Fixes:  #1084 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->


- [X ] New feature (non-breaking change which adds functionality)


# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [ X] I have made this from my own
- [ ] I have taken help from some online resourses 
- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
<img width="486" alt="Screenshot 2024-06-07 at 12 19 02 AM" src="https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109761760/09a0240f-3d0d-4ad0-8e9e-1c3beb799cb0">
<img width="966" alt="Screenshot 2024-06-07 at 12 19 18 AM" src="https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109761760/c8810e24-c50b-4209-bc76-d070e52eb52a">
