### PR TITLE
added spline extension

### DIFF
--- a/Spline/manifest.json
+++ b/Spline/manifest.json
@@ -1,0 +1,18 @@
+{
+    "manifest_version": 3,
+    "name": "Spline Extension",
+    "version": "1.0",
+    "description": "Navigate to the Spline extension functionality quickly and easily.",
+    "action": {
+      "default_popup": "welcome.html",
+      "default_icon": {
+        "16": "icon16.png",
+        "48": "icon48.png",
+        "128": "icon128.png"
+      }
+    },
+    "permissions": [
+      "activeTab"
+    ]
+  }
+  

--- a/Spline/popup.html
+++ b/Spline/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Spline Extension</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Spline Extension</h1>
+    <p>Click the button below to navigate to the provided Spline link.</p>
+    <button id="spline-link">Go to Spline</button>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/Spline/popup.js
+++ b/Spline/popup.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const splineLink = document.getElementById('spline-link');
+    splineLink.addEventListener('click', function() {
+      chrome.tabs.create({ url: "https://app.spline.design/home" });
+    });
+  });
+  

--- a/Spline/styles.css
+++ b/Spline/styles.css
@@ -1,0 +1,42 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    background-color: #f3f3f3;
+    color: #333;
+  }
+  
+  .container {
+    text-align: center;
+  }
+  
+  .typewriter {
+    font-size: 24px;
+    border-right: 2px solid;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  
+  #start-spline-extension {
+    margin-top: 20px;
+    padding: 10px 20px;
+    font-size: 16px;
+    background-color: #fff;
+    color: #333;
+    border: none;
+    cursor: pointer;
+  }
+  
+  #spline-link {
+    display: block;
+    margin-top: 20px;
+    padding: 10px 20px;
+    background-color: #fff;
+    color: #333;
+    text-decoration: none;
+  }
+  

--- a/Spline/welcome.html
+++ b/Spline/welcome.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <div id="welcome-text" class="typewriter"></div>
+    <button id="start-spline-extension" style="display: none;">Start Spline Extension</button>
+  </div>
+  <script src="welcome.js"></script>
+</body>
+</html>

--- a/Spline/welcome.js
+++ b/Spline/welcome.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const welcomeText = "Welcome to the Spline Extension! Explore the world of 3D design.";
+    const welcomeElement = document.getElementById('welcome-text');
+    const startSplineExtensionButton = document.getElementById('start-spline-extension');
+    let i = 0;
+  
+    function typeWriter() {
+      if (i < welcomeText.length) {
+        welcomeElement.innerHTML += welcomeText.charAt(i);
+        i++;
+        setTimeout(typeWriter, 100);
+      } else {
+        startSplineExtensionButton.style.display = 'block';
+      }
+    }
+  
+    typeWriter();
+  
+    startSplineExtensionButton.addEventListener('click', function() {
+      chrome.action.setPopup({ popup: 'popup.html' });
+      window.location.href = 'popup.html';
+    });
+  });
+  


### PR DESCRIPTION
# Description

This pull request introduces a new Chrome extension named "Spline Extension" that provides users with quick and easy access to the Spline 3D design tool. The extension includes a welcome page with a typewriter effect that greets users and invites them to explore the Spline tool. Upon clicking the button, users are directed to the Spline home page.

Fixes:  #1105 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->


- [ X] New feature (non-breaking change which adds functionality)


# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [ X] I have made this from my own
- [ ] I have taken help from some online resourses 
- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
<img width="777" alt="Screenshot 2024-06-07 at 12 35 56 AM" src="https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109761760/8bf3728b-153c-468d-920c-e1f1696edf7c">

<img width="471" alt="Screenshot 2024-06-07 at 12 35 41 AM" src="https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109761760/fff03365-b767-429e-b787-1b635095915a">
