### PR TITLE
added ruby code editor extension

### DIFF
--- a/Ruby Code Editor/background.js
+++ b/Ruby Code Editor/background.js
@@ -1,0 +1,4 @@
+chrome.runtime.onInstalled.addListener(() => {
+    console.log("Ruby Code Editor Extension installed");
+  });
+  

--- a/Ruby Code Editor/manifest.json
+++ b/Ruby Code Editor/manifest.json
@@ -1,0 +1,19 @@
+{
+    "manifest_version": 3,
+    "name": "Ruby Code Editor",
+    "version": "1.0",
+    "description": "Navigate to Ruby Code Editor with one click.",
+    "permissions": ["activeTab"],
+    "action": {
+      "default_popup": "popup.html",
+      "default_icon": {
+        "16": "icons/icon16.png",
+        "48": "icons/icon48.png",
+        "128": "icons/icon128.png"
+      }
+    },
+    "background": {
+      "service_worker": "background.js"
+    }
+  }
+  

--- a/Ruby Code Editor/popup.html
+++ b/Ruby Code Editor/popup.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Ruby Code Editor</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: linear-gradient(to right, #3a7bd5, #3a6073);
+      color: white;
+      text-align: center;
+      padding: 20px;
+    }
+    button {
+      background-color: #4CAF50;
+      border: none;
+      color: white;
+      padding: 15px 32px;
+      text-align: center;
+      text-decoration: none;
+      display: inline-block;
+      font-size: 16px;
+      margin: 20px 2px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <h1>Ruby Code Editor</h1>
+  <button id="navigate">Go to Ruby Code Editor</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/Ruby Code Editor/popup.js
+++ b/Ruby Code Editor/popup.js
@@ -1,0 +1,4 @@
+document.getElementById('navigate').addEventListener('click', function() {
+    chrome.tabs.create({ url: 'welcome.html' });
+  });
+  

--- a/Ruby Code Editor/typewriter.css
+++ b/Ruby Code Editor/typewriter.css
@@ -1,0 +1,40 @@
+body {
+    font-family: Arial, sans-serif;
+    background: linear-gradient(to right, #3a7bd5, #3a6073);
+    color: white;
+    text-align: center;
+    padding: 20px;
+  }
+  
+  .typewriter h1 {
+    overflow: hidden;
+    border-right: .15em solid white;
+    white-space: nowrap;
+    margin: 0 auto;
+    letter-spacing: .15em;
+    animation: typing 3.5s steps(40, end), blink-caret .75s step-end infinite;
+  }
+  
+  @keyframes typing {
+    from { width: 0 }
+    to { width: 100% }
+  }
+  
+  @keyframes blink-caret {
+    from, to { border-color: transparent }
+    50% { border-color: white; }
+  }
+  
+  button {
+    background-color: #4CAF50;
+    border: none;
+    color: white;
+    padding: 15px 32px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 20px 2px;
+    cursor: pointer;
+  }
+  

--- a/Ruby Code Editor/welcome.html
+++ b/Ruby Code Editor/welcome.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Welcome to Ruby Code Editor</title>
+  <link rel="stylesheet" type="text/css" href="typewriter.css">
+</head>
+<body>
+  <div class="typewriter">
+    <h1>Welcome to Ruby Code Editor</h1>
+  </div>
+  <button id="navigate">Go to Ruby Code Editor</button>
+  <script src="welcome.js"></script>
+</body>
+</html>

--- a/Ruby Code Editor/welcome.js
+++ b/Ruby Code Editor/welcome.js
@@ -1,0 +1,4 @@
+document.getElementById('navigate').addEventListener('click', function() {
+    window.location.href = 'https://www.onlinegdb.com/online_ruby_compiler';
+  });
+  


### PR DESCRIPTION
# Description

This change introduces a new Chrome extension that provides users with quick access to an online Ruby Code Editor. The extension displays a welcome page with a typewriter effect and then navigates users to the Ruby Code Editor at the provided link.



Fixes:  #1147 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->


- [X ] New feature (non-breaking change which adds functionality)


# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [X ] I have made this from my own
- [ ] I have taken help from some online resourses 
- [ X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
<img width="330" alt="Screenshot 2024-06-08 at 10 37 30 PM" src="https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109761760/bd01c89b-7aa1-46f2-a779-89965e33897c">
<img width="634" alt="Screenshot 2024-06-08 at 10 37 45 PM" src="https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/109761760/9a04ad0b-8686-4aed-8f2a-e201f1945517">
