### PR TITLE
Added a 10 sec alert popup in Pictionary Game

### DIFF
--- a/Pictionary Game/Index.html
+++ b/Pictionary Game/Index.html
@@ -22,6 +22,7 @@
           <p>Time Left: <span id="timer"></span></p>
           <p>Scores: <span id="scores"></span></p>
         </div>
+        <div id="alert"></div>
         <canvas id="drawingCanvas"></canvas>
         <div class="controls">
           <button id="guess-button">Guess</button>

--- a/Pictionary Game/scripts/script.js
+++ b/Pictionary Game/scripts/script.js
@@ -53,9 +53,18 @@ function startTimer() {
   clearInterval(timer);
   timeLeft = 60;
   timerElement.textContent = timeLeft;
+  const alertElement = document.getElementById("alert");
+  alertElement.style.display = "none"; // Hide the alert initially
+
   timer = setInterval(() => {
     timeLeft--;
     timerElement.textContent = timeLeft;
+
+    if (timeLeft <= 10) {
+      alertElement.style.display = "block"; // Show the alert
+      alertElement.textContent = `${timeLeft} seconds left`;
+    }
+
     if (timeLeft <= 0) {
       clearInterval(timer);
       alert(`${players[currentPlayerIndex]} ran out of time!`);

--- a/Pictionary Game/src/styles.css
+++ b/Pictionary Game/src/styles.css
@@ -129,3 +129,16 @@ canvas {
   font-size: 1.1em;
   color: #333;
 }
+
+#alert {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: red;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 10px;
+  font-size: 1.2em;
+  display: none;
+}


### PR DESCRIPTION
# Description

Added a 10 seconds countdown alert to the game. It will keep players informed about the remaining time, helping them manage their strategies and efforts more effectively. Knowing the game is about to end can motivate players to make a final push, potentially leading to higher scores and a more satisfying game experience.

Fixes:  #1350

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


# SCREEN-SHOTS 

![10 sec alert](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/151942535/5d97245a-3cb6-4179-afb4-6933e9bdbfed)

![Alert popup](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/151942535/e1bc8172-8a6f-4bf4-80cf-8018d2d8d8ee)
