### PR TITLE
colour-code-converter

### DIFF
--- a/Color Code Converter/converter.js
+++ b/Color Code Converter/converter.js
@@ -1,0 +1,520 @@
+// RGB , RGBA, Hex, HSL, HSV, CMYK
+
+function RGBtoRGBA(input) {
+    // input format: rgb(255, 255, 255) or rgb(255,255,255) or (255, 255, 255) or (255,255,255) or 255, 255, 255 or 255,255,255
+    try {
+        input = input.replace('rgb(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        for (let i = 0; i < input.length; i++) {
+            // .trim() removes whitespace from both sides of a string
+            input[i] = parseInt(input[i].trim());
+        }
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 3) {
+        return 'Invalid input';
+    }
+    if (input.some((value) => value < 0 || value > 255)) {
+        return 'Invalid input';
+    }
+    return `rgba(${input[0]}, ${input[1]}, ${input[2]}, 1)`;
+}
+
+function RGBtoHex(input) {
+    // input format: rgb(255, 255, 255) or rgb(255,255,255) or (255, 255, 255) or (255,255,255) or 255, 255, 255 or 255,255,255
+    try {
+        input = input.replace('rgb(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        for (let i = 0; i < input.length; i++) {
+            // .trim() removes whitespace from both sides of a string
+            input[i] = parseInt(input[i].trim());
+        }
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 3) {
+        return 'Invalid input';
+    }
+    if (input.some((value) => value < 0 || value > 255)) {
+        return 'Invalid input';
+    }
+    let result = '#';
+    for (let i = 0; i < input.length; i++) {
+        let hex = input[i].toString(16);
+        if (hex.length === 1) {
+            hex = '0' + hex;
+        }
+        result += hex;
+    }
+    return result
+}
+
+function RGBtoHSL(input) {
+    // input format: rgb(255, 255, 255) or rgb(255,255,255) or (255, 255, 255) or (255,255,255) or 255, 255, 255 or 255,255,255
+    try {
+        input = input.replace('rgb(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        for (let i = 0; i < input.length; i++) {
+            // .trim() removes whitespace from both sides of a string
+            input[i] = parseInt(input[i].trim());
+        }
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 3) {
+        return 'Invalid input';
+    }
+    if (input.some((value) => value < 0 || value > 255)) {
+        return 'Invalid input';
+    }
+    let r = input[0] / 255;
+    let g = input[1] / 255;
+    let b = input[2] / 255;
+    let min = Math.min(r, g, b);
+    let max = Math.max(r, g, b);
+    let delta = max - min;
+    let h, s, l;
+    if (delta === 0) {
+        h = 0;
+    } else if (max === r) {
+        h = ((g - b) / delta) % 6;
+    } else if (max === g) {
+        h = (b - r) / delta + 2;
+    } else if (max === b) {
+        h = (r - g) / delta + 4;
+    }
+    h = Math.round(h * 60);
+    if (h < 0) {
+        h += 360;
+    }
+    l = (min + max) / 2;
+    s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+    s = +(s * 100).toFixed(1);
+    l = +(l * 100).toFixed(1);
+    return `hsl(${h}, ${s}%, ${l}%)`;
+}
+
+function RGBtoHSV(input) {
+    // input format: rgb(255, 255, 255) or rgb(255,255,255) or (255, 255, 255) or (255,255,255) or 255, 255, 255 or 255,255,255
+    try {
+        input = input.replace('rgb(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        for (let i = 0; i < input.length; i++) {
+            // .trim() removes whitespace from both sides of a string
+            input[i] = parseInt(input[i].trim());
+        }
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 3) {
+        return 'Invalid input';
+    }
+    if (input.some((value) => value < 0 || value > 255)) {
+        return 'Invalid input';
+    }
+    let r = input[0] / 255;
+    let g = input[1] / 255;
+    let b = input[2] / 255;
+    let min = Math.min(r, g, b);
+    let max = Math.max(r, g, b);
+    let delta = max - min;
+    let h, s, v;
+    if (delta === 0) {
+        h = 0;
+    } else if (max === r) {
+        h = ((g - b) / delta) % 6;
+    } else if (max === g) {
+        h = (b - r) / delta + 2;
+    } else if (max === b) {
+        h = (r - g) / delta + 4;
+    }
+    h = Math.round(h * 60);
+    if (h < 0) {
+        h += 360;
+    }
+    s = delta === 0 ? 0 : delta / max;
+    s = +(s * 100).toFixed(1);
+    v = +(max * 100).toFixed(1);
+    return `hsv(${h}, ${s}%, ${v}%)`;
+}
+
+function RGBtoCMYK(input) {
+    // input format: rgb(255, 255, 255) or rgb(255,255,255) or (255, 255, 255) or (255,255,255) or 255, 255, 255 or 255,255,255
+    try {
+        input = input.replace('rgb(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        for (let i = 0; i < input.length; i++) {
+            // .trim() removes whitespace from both sides of a string
+            input[i] = parseInt(input[i].trim());
+        }
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 3) {
+        return 'Invalid input';
+    }
+    if (input.some((value) => value < 0 || value > 255)) {
+        return 'Invalid input';
+    }
+    let r = input[0] / 255;
+    let g = input[1] / 255;
+    let b = input[2] / 255;
+    let k = 1 - Math.max(r, g, b);
+    let c = (1 - r - k) / (1 - k);
+    let m = (1 - g - k) / (1 - k);
+    let y = (1 - b - k) / (1 - k);
+    c = +(c * 100).toFixed(1);
+    m = +(m * 100).toFixed(1);
+    y = +(y * 100).toFixed(1);
+    k = +(k * 100).toFixed(1);
+    return `cmyk(${c}%, ${m}%, ${y}%, ${k}%)`;
+}
+
+function RGBAtoRGB(input) {
+    // input format: rgba(255, 255, 255, 1) or rgba(255,255,255,1) or (255, 255, 255, 1) or (255,255,255,1) or 255, 255, 255, 1 or 255,255,255,1
+    console.log("function triggered")
+    try {
+        input = input.replace('rgba(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        for (let i = 0; i < input.length; i++) {
+            // .trim() removes whitespace from both sides of a string
+            input[i] = parseInt(input[i].trim());
+        }
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 4) {
+        return 'Invalid input';
+    }
+    if (input.some((value) => value < 0 || value > 255)) {
+        return 'Invalid input';
+    }
+    return `rgb(${input[0]}, ${input[1]}, ${input[2]})`;
+}
+
+function RGBAtoHex(input) {
+    // input format: rgba(255, 255, 255, 1) or rgba(255,255,255,1) or (255, 255, 255, 1) or (255,255,255,1) or 255, 255, 255, 1 or 255,255,255,1
+    try {
+        input = input.replace('rgba(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        for (let i = 0; i < input.length; i++) {
+            // .trim() removes whitespace from both sides of a string
+            input[i] = parseInt(input[i].trim());
+        }
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 4) {
+        return 'Invalid input';
+    }
+    if (input.some((value) => value < 0 || value > 255)) {
+        return 'Invalid input';
+    }
+    let result = '#';
+    for (let i = 0; i < input.length - 1; i++) {
+        let hex = input[i].toString(16);
+        if (hex.length === 1) {
+            hex = '0' + hex;
+        }
+        result += hex;
+    }
+    return result
+}
+
+function RGBAtoHSL(input) {
+    input = RGBAtoRGB(input);
+    return RGBtoHSL(input);
+}
+
+function RGBAtoHSV(input) {
+    input = RGBAtoRGB(input);
+    return RGBtoHSV(input);
+}
+
+function RGBAtoCMYK(input) {
+    input = RGBAtoRGB(input);
+    return RGBtoCMYK(input);
+}
+
+function HextoRGB(input) {
+    // input format: #ffffff or ffffff
+    try {
+        input = input.replace('#', '');
+        if (input.length !== 6) {
+            return 'Invalid input';
+        }
+        input = input.match(/.{2}/g);
+        for (let i = 0; i < input.length; i++) {
+            input[i] = parseInt(input[i], 16);
+        }
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.some((value) => value < 0 || value > 255)) {
+        return 'Invalid input';
+    }
+    return `rgb(${input[0]}, ${input[1]}, ${input[2]})`;
+}
+
+function HextoRGBA(input) {
+    input = HextoRGB(input);
+    return RGBtoRGBA(input);
+}
+
+function HextoHSL(input) {
+    input = HextoRGB(input);
+    return RGBtoHSL(input);
+}
+
+function HextoHSV(input) {
+    input = HextoRGB(input);
+    return RGBtoHSV(input);
+}
+
+function HextoCMYK(input) {
+    input = HextoRGB(input);
+    return RGBtoCMYK(input);
+}
+
+function HSLtoRGB(input) {
+    // input format: hsl(360, 100%, 100%) or hsl(360,100%,100%) or (360, 100%, 100%) or (360,100%,100%) or 360, 100%, 100% or 360,100%,100%
+    try {
+        input = input.replace('hsl(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        input[0] = parseInt(input[0].trim());
+        input[1] = parseInt(input[1].replace('%', '').trim());
+        input[2] = parseInt(input[2].replace('%', '').trim());
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 3) {
+        return 'Invalid input';
+    }
+    if (input[0] < 0 || input[0] > 360 || input[1] < 0 || input[1] > 100 || input[2] < 0 || input[2] > 100) {
+        return 'Invalid input';
+    }
+    let h = input[0] / 360;
+    let s = input[1] / 100;
+    let l = input[2] / 100;
+    let r, g, b;
+    if (s === 0) {
+        r = g = b = l;
+    } else {
+        let hue2rgb = (p, q, t) => {
+            if (t < 0) {
+                t += 1;
+            }
+            if (t > 1) {
+                t -= 1;
+            }
+            if (t < 1 / 6) {
+                return p + (q - p) * 6 * t;
+            }
+            if (t < 1 / 2) {
+                return q;
+            }
+            if (t < 2 / 3) {
+                return p + (q - p) * (2 / 3 - t) * 6;
+            }
+            return p;
+        }
+        let q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+        let p = 2 * l - q;
+        r = hue2rgb(p, q, h + 1 / 3);
+        g = hue2rgb(p, q, h);
+        b = hue2rgb(p, q, h - 1 / 3);
+    }
+    r = Math.round(r * 255);
+    g = Math.round(g * 255);
+    b = Math.round(b * 255);
+    return `rgb(${r}, ${g}, ${b})`;
+}
+
+function HSLtoRGBA(input) {
+    input = HSLtoRGB(input);
+    return RGBtoRGBA(input);
+}
+
+function HSLtoHex(input) {
+    input = HSLtoRGB(input);
+    return RGBtoHex(input);
+}
+
+function HSLtoHSV(input) {
+    input = HSLtoRGB(input);
+    return RGBtoHSV(input);
+}
+
+function HSLtoCMYK(input) {
+    input = HSLtoRGB(input);
+    return RGBtoCMYK(input);
+}
+
+function HSVtoRGB(input) {
+    // input format: hsv(360, 100%, 100%) or hsv(360,100%,100%) or (360, 100%, 100%) or (360,100%,100%) or 360, 100%, 100% or 360,100%,100%
+    try {
+        input = input.replace('hsv(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        input[0] = parseInt(input[0].trim());
+        input[1] = parseInt(input[1].replace('%', '').trim());
+        input[2] = parseInt(input[2].replace('%', '').trim());
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 3) {
+        return 'Invalid input';
+    }
+    if (input[0] < 0 || input[0] > 360 || input[1] < 0 || input[1] > 100 || input[2] < 0 || input[2] > 100) {
+        return 'Invalid input';
+    }
+    let h = input[0] / 360;
+    let s = input[1] / 100;
+    let v = input[2] / 100;
+    let r, g, b;
+    let i = Math.floor(h * 6);
+    let f = h * 6 - i;
+    let p = v * (1 - s);
+    let q = v * (1 - f * s);
+    let t = v * (1 - (1 - f) * s);
+    switch (i % 6) {
+        case 0:
+            r = v;
+            g = t;
+            b = p;
+            break;
+        case 1:
+            r = q;
+            g = v;
+            b = p;
+            break;
+        case 2:
+            r = p;
+            g = v;
+            b = t;
+            break;
+        case 3:
+            r = p;
+            g = q;
+            b = v;
+            break;
+        case 4:
+            r = t;
+            g = p;
+            b = v;
+            break;
+        case 5:
+            r = v;
+            g = p;
+            b = q;
+            break;
+    }
+    r = Math.round(r * 255);
+    g = Math.round(g * 255);
+    b = Math.round(b * 255);
+    return `rgb(${r}, ${g}, ${b})`;
+}
+
+function HSVtoRGBA(input) {
+    input = HSVtoRGB(input);
+    return RGBtoRGBA(input);
+}
+
+function HSVtoHex(input) {
+    input = HSVtoRGB(input);
+    return RGBtoHex(input);
+}
+
+function HSVtoHSL(input) {
+    input = HSVtoRGB(input);
+    return RGBtoHSL(input);
+}
+
+function HSVtoCMYK(input) {
+    input = HSVtoRGB(input);
+    return RGBtoCMYK(input);
+}
+
+function CMYKtoRGB(input) {
+    // input format: cmyk(100%, 100%, 100%, 100%) or cmyk(100%,100%,100%,100%) or (100%, 100%, 100%, 100%) or (100%,100%,100%,100%) or 100%, 100%, 100%, 100% or 100%,100%,100%,100%
+    try {
+        input = input.replace('cmyk(', '');
+        input = input.replace(')', '');
+        input = input.split(', ');
+        input[0] = parseInt(input[0].replace('%', '').trim());
+        input[1] = parseInt(input[1].replace('%', '').trim());
+        input[2] = parseInt(input[2].replace('%', '').trim());
+        input[3] = parseInt(input[3].replace('%', '').trim());
+    } catch (error) {
+        console.log(error)
+        return 'Invalid input';
+    }
+    console.log(input)
+    if (input.length !== 4) {
+        return 'Invalid input';
+    }
+    if (input.some((value) => value < 0 || value > 100)) {
+        return 'Invalid input';
+    }
+    let c = input[0] / 100;
+    let m = input[1] / 100;
+    let y = input[2] / 100;
+    let k = input[3] / 100;
+    let r = 1 - Math.min(1, c * (1 - k) + k);
+    let g = 1 - Math.min(1, m * (1 - k) + k);
+    let b = 1 - Math.min(1, y * (1 - k) + k);
+    r = Math.round(r * 255);
+    g = Math.round(g * 255);
+    b = Math.round(b * 255);
+    return `rgb(${r}, ${g}, ${b})`;
+}
+
+function CMYKtoRGBA(input) {
+    input = CMYKtoRGB(input);
+    return RGBtoRGBA(input);
+}
+
+function CMYKtoHex(input) {
+    input = CMYKtoRGB(input);
+    return RGBtoHex(input);
+}
+
+function CMYKtoHSL(input) {
+    input = CMYKtoRGB(input);
+    return RGBtoHSL(input);
+}
+
+function CMYKtoHSV(input) {
+    input = CMYKtoRGB(input);
+    return RGBtoHSV(input);
+}
+

--- a/Color Code Converter/index.html
+++ b/Color Code Converter/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@500&display=swap" rel="stylesheet">
+    <link rel="manifest" href="manifest.json">
+    <title>Color Code Converter</title>
+</head>
+
+<body>
+    <div class="waviy">
+        <span style="--i:1">C</span>
+        <span style="--i:2">O</span>
+        <span style="--i:3">L</span>
+        <span style="--i:4">O</span>
+        <span style="--i:5">R</span>
+        <span style="--i:6">&nbsp;</span>
+        <span style="--i:7">C</span>
+        <span style="--i:8">O</span>
+        <span style="--i:9">D</span>
+        <span style="--i:10">E</span>
+        <span style="--i:11">&nbsp;</span>
+        <span style="--i:12">C</span>
+        <span style="--i:13">O</span>
+        <span style="--i:14">N</span>
+        <span style="--i:15">V</span>
+        <span style="--i:16">E</span>
+        <span style="--i:17">R</span>
+        <span style="--i:18">T</span>
+        <span style="--i:19">E</span>
+        <span style="--i:20">R</span>
+    </div>
+    <br><br>
+    <div class="card">
+        <div class="row input">
+            <div class="dropdowns">
+                <div class="dropdown">
+                    <select name="convertFrom" id="convertFrom">
+                        <option value="hex">HEXCODE</option>
+                        <option value="rgb">RGB</option>
+                        <option value="rgba">RGBA</option>
+                        <option value="hsl">HSL</option>
+                        <option value="hsv">HSV</option>
+                        <option value="cmyk">CMYK</option>
+                    </select>
+                </div>
+            </div>
+            <input type="text" id="input" placeholder="Enter a value">
+        </div>
+        <br><br>
+        <div class="row">
+            <div class="buttons">
+                <button id="convert">Convert 🔄</button>
+                <button id="copy">Copy📂 </button>
+                <button id="reset">Reset ❌</button>
+            </div>
+        </div>
+        <br><br>
+        <div class="row result">
+            <div class="dropdowns">
+                <div class="dropdown">
+                    <select name="convertTo" id="convertTo">
+                        <option value="rgb">RGB</option>
+                        <option value="hex">HEXCODE</option>
+                        <option value="rgba">RGBA</option>
+                        <option value="hsl">HSL</option>
+                        <option value="hsv">HSV</option>
+                        <option value="cmyk">CMYK</option>
+                    </select>
+                </div>
+            </div>
+            <textarea id="result" placeholder="Result" rows="3" readonly></textarea>
+        </div>
+    </div>
+    <script src="converter.js"></script>
+    <script src="script.js"></script>
+</body>
+
+</html>

--- a/Color Code Converter/manifest.json
+++ b/Color Code Converter/manifest.json
@@ -1,0 +1,40 @@
+{
+    "name": "Color Code Converter",
+    "short_name": "ColorConverter",
+    "version": "1.0.0",
+    "description": "A simple tool to convert color codes between HEX, RGB, RGBA, HSL, HSV, and CMYK formats.",
+    "manifest_version": 2,
+    "icons": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    },
+    "start_url": "index.html",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#000000",
+    "permissions": [],
+    "browser_action": {
+      "default_popup": "index.html",
+      "default_icon": {
+        "16": "icons/icon16.png",
+        "48": "icons/icon48.png",
+        "128": "icons/icon128.png"
+      }
+    },
+    "content_scripts": [
+      {
+        "js": ["converter.js", "script.js"],
+        "css": ["style.css"]
+      }
+    ],
+    "web_accessible_resources": [
+      "icons/icon16.png",
+      "icons/icon48.png",
+      "icons/icon128.png",
+      "style.css",
+      "assets/converter.js",
+      "script.js"
+    ]
+}
+  

--- a/Color Code Converter/script.js
+++ b/Color Code Converter/script.js
@@ -1,0 +1,340 @@
+document.getElementById('convert').addEventListener('click', convertColors);
+document.getElementById('copy').addEventListener('click', copyToClipboard);
+document.getElementById('reset').addEventListener('click', resetFields);
+
+function convertColors() {
+    const input = document.getElementById('input').value;
+    const convertFrom = document.getElementById('convertFrom').value;
+    const convertTo = document.getElementById('convertTo').value;
+    console.log(input, convertFrom, convertTo)
+
+    let result;
+    let pat;
+
+    switch (convertFrom) {
+        case 'rgb':
+            pat = "rgb(255, 255, 255)";
+            result = convertRGB(input, convertTo);
+            break;
+        case 'rgba':
+            pat = "rgba(255, 255, 255, 1)";
+            result = convertRGBA(input, convertTo);
+            break;
+        case 'hex':
+            pat = "#ffffff";
+            result = convertHex(input, convertTo);
+            break;
+        case 'hsl':
+            pat = "hsl(360, 100%, 100%)";
+            result = convertHSL(input, convertTo);
+            break;
+        case 'hsv':
+            pat = "hsv(360, 100%, 100%)";
+            result = convertHSV(input, convertTo);
+            break;
+        case 'cmyk':
+            pat = "cmyk(100%, 100%, 100%, 100%)";
+            result = convertCMYK(input, convertTo);
+            break;
+    }
+    document.getElementById('result').value = result;
+}
+
+function copyToClipboard() {
+    const result = document.getElementById('result');
+    result.select();
+    document.execCommand('copy');
+    alert('Copied to clipboard');
+}
+
+function resetFields() {
+    document.getElementById('input').value = '';
+    document.getElementById('result').value = '';
+}
+
+function convertRGB(input, convertTo) {
+    // Conversion logic for RGB
+    let result = "";
+    const rgb = input.replace(/[^\d,]/g, '').split(',');
+
+    switch (convertTo) {
+        case 'hex':
+            result = '#' + rgb.map(x => {
+                const hex = parseInt(x).toString(16);
+                return hex.length === 1 ? '0' + hex : hex;
+            }).join('');
+            break;
+        case 'rgba':
+            result = `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, 1)`;
+            break;
+        case 'hsl':
+            result = rgbToHsl(rgb[0], rgb[1], rgb[2]);
+            break;
+        case 'hsv':
+            result = rgbToHsv(rgb[0], rgb[1], rgb[2]);
+            break;
+        case 'cmyk':
+            result = rgbToCmyk(rgb[0], rgb[1], rgb[2]);
+            break;
+    }
+    return result;
+}
+
+function convertRGBA(input, convertTo) {
+    // Conversion logic for RGBA
+    let result = "";
+    const rgba = input.replace(/[^\d,.]/g, '').split(',');
+
+    switch (convertTo) {
+        case 'hex':
+            const rgbPart = rgba.slice(0, 3).map(x => {
+                const hex = parseInt(x).toString(16);
+                return hex.length === 1 ? '0' + hex : hex;
+            }).join('');
+            const alphaPart = Math.round(parseFloat(rgba[3]) * 255).toString(16).padStart(2, '0');
+            result = `#${rgbPart}${alphaPart}`;
+            break;
+        case 'rgb':
+            result = `rgb(${rgba[0]}, ${rgba[1]}, ${rgba[2]})`;
+            break;
+        case 'hsl':
+            result = rgbToHsl(rgba[0], rgba[1], rgba[2]);
+            break;
+        case 'hsv':
+            result = rgbToHsv(rgba[0], rgba[1], rgba[2]);
+            break;
+        case 'cmyk':
+            result = rgbToCmyk(rgba[0], rgba[1], rgba[2]);
+            break;
+    }
+    return result;
+}
+
+function convertHex(input, convertTo) {
+    // Conversion logic for HEX
+    let result = "";
+    const hex = input.replace('#', '');
+
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+
+    switch (convertTo) {
+        case 'rgb':
+            result = `rgb(${r}, ${g}, ${b})`;
+            break;
+        case 'rgba':
+            result = `rgba(${r}, ${g}, ${b}, 1)`;
+            break;
+        case 'hsl':
+            result = rgbToHsl(r, g, b);
+            break;
+        case 'hsv':
+            result = rgbToHsv(r, g, b);
+            break;
+        case 'cmyk':
+            result = rgbToCmyk(r, g, b);
+            break;
+    }
+    return result;
+}
+
+function convertHSL(input, convertTo) {
+    // Conversion logic for HSL
+    let result = "";
+    const hsl = input.replace(/[^\d,.%]/g, '').split(',');
+
+    const h = parseInt(hsl[0]);
+    const s = parseInt(hsl[1].replace('%', ''));
+    const l = parseInt(hsl[2].replace('%', ''));
+
+    switch (convertTo) {
+        case 'rgb':
+            result = hslToRgb(h, s, l);
+            break;
+        case 'rgba':
+            result = hslToRgb(h, s, l).replace('rgb', 'rgba').replace(')', ', 1)');
+            break;
+        case 'hex':
+            result = rgbToHex(hslToRgb(h, s, l));
+            break;
+        case 'hsv':
+            result = hslToHsv(h, s, l);
+            break;
+        case 'cmyk':
+            result = rgbToCmyk(hslToRgb(h, s, l).replace('rgb(', '').replace(')', '').split(','));
+            break;
+    }
+    return result;
+}
+
+function convertHSV(input, convertTo) {
+    // Conversion logic for HSV
+    let result = "";
+    const hsv = input.replace(/[^\d,.%]/g, '').split(',');
+
+    const h = parseInt(hsv[0]);
+    const s = parseInt(hsv[1].replace('%', ''));
+    const v = parseInt(hsv[2].replace('%', ''));
+
+    switch (convertTo) {
+        case 'rgb':
+            result = hsvToRgb(h, s, v);
+            break;
+        case 'rgba':
+            result = hsvToRgb(h, s, v).replace('rgb', 'rgba').replace(')', ', 1)');
+            break;
+        case 'hex':
+            result = rgbToHex(hsvToRgb(h, s, v));
+            break;
+        case 'hsl':
+            result = hsvToHsl(h, s, v);
+            break;
+        case 'cmyk':
+            result = rgbToCmyk(hsvToRgb(h, s, v).replace('rgb(', '').replace(')', '').split(','));
+            break;
+    }
+    return result;
+}
+
+function convertCMYK(input, convertTo) {
+    // Conversion logic for CMYK
+    let result = "";
+    const cmyk = input.replace(/[^\d,.%]/g, '').split(',');
+
+    const c = parseInt(cmyk[0].replace('%', ''));
+    const m = parseInt(cmyk[1].replace('%', ''));
+    const y = parseInt(cmyk[2].replace('%', ''));
+    const k = parseInt(cmyk[3].replace('%', ''));
+
+    switch (convertTo) {
+        case 'rgb':
+            result = cmykToRgb(c, m, y, k);
+            break;
+        case 'rgba':
+            result = cmykToRgb(c, m, y, k).replace('rgb', 'rgba').replace(')', ', 1)');
+            break;
+        case 'hex':
+            result = rgbToHex(cmykToRgb(c, m, y, k));
+            break;
+        case 'hsl':
+            result = rgbToHsl(cmykToRgb(c, m, y, k).replace('rgb(', '').replace(')', '').split(','));
+            break;
+        case 'hsv':
+            result = rgbToHsv(cmykToRgb(c, m, y, k).replace('rgb(', '').replace(')', '').split(','));
+            break;
+    }
+    return result;
+}
+
+function rgbToHsl(r, g, b) {
+    // Conversion from RGB to HSL
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    let h, s, l = (max + min) / 2;
+    if (max === min) {
+        h = s = 0; // achromatic
+    } else {
+        const d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        switch (max) {
+            case r:
+                h = (g - b) / d + (g < b ? 6 : 0);
+                break;
+            case g:
+                h = (b - r) / d + 2;
+                break;
+            case b:
+                h = (r - g) / d + 4;
+                break;
+        }
+        h /= 6;
+    }
+    return `hsl(${Math.round(h * 360)}, ${Math.round(s * 100)}%, ${Math.round(l * 100)}%)`;
+}
+
+function rgbToHsv(r, g, b) {
+    // Conversion from RGB to HSV
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const d = max - min;
+    const s = max === 0 ? 0 : d / max;
+    const v = max;
+    let h;
+    switch (max) {
+        case min:
+            h = 0;
+    }
+}
+
+// Define the default background color
+const defaultBackgroundColor = 'linear-gradient(to right bottom, #7ed0e7, #77c1ee, #87afee, #a399e1, #bf80c6)';
+
+document.addEventListener('DOMContentLoaded', function () {
+    document.getElementById('convert').addEventListener('click', convertColors);
+    document.getElementById('reset').addEventListener('click', resetBackground);
+});
+
+function convertColors() {
+    const input = document.getElementById('input').value;
+    const convertFrom = document.getElementById('convertFrom').value;
+    const convertTo = document.getElementById('convertTo').value;
+
+    let result;
+
+    switch (convertFrom) {
+        case 'rgb':
+            result = convertRGB(input, convertTo);
+            break;
+        case 'rgba':
+            result = convertRGBA(input, convertTo);
+            break;
+        case 'hex':
+            result = convertHex(input, convertTo);
+            break;
+        case 'hsl':
+            result = convertHSL(input, convertTo);
+            break;
+        case 'hsv':
+            result = convertHSV(input, convertTo);
+            break;
+        case 'cmyk':
+            result = convertCMYK(input, convertTo);
+            break;
+        default:
+            result = 'Invalid conversion';
+    }
+
+    if (isValidColor(result)) {
+        document.body.style.background = result;
+    } else {
+        console.log('Invalid color code');
+    }
+
+    document.getElementById('result').value = result;
+}
+
+function resetBackground() {
+    // Reset the body's background color to the default
+    document.body.style.background = defaultBackgroundColor;
+
+    // Clear the input and result fields
+    document.getElementById('input').value = '';
+    document.getElementById('result').value = '';
+}
+
+function isValidColor(colorCode) {
+    const s = new Option().style;
+    s.color = colorCode;
+    return s.color !== '';
+}
+
+// Your existing conversion functions go here
+
+

--- a/Color Code Converter/style.css
+++ b/Color Code Converter/style.css
@@ -1,0 +1,136 @@
+@import url('https://fonts.googleapis.com/css2?family=Alfa+Slab+One&display=swap');
+
+* {
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Inconsolata', monospace;
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    background: linear-gradient(to right bottom, #7ed0e7, #77c1ee, #87afee, #a399e1, #bf80c6);
+    height: 100vh;
+    margin: 0;
+    /* background-image: url(./assets/background.png); */
+    background-size: cover;
+    background-position: center;
+}
+
+.waviy {
+    position: relative;
+    -webkit-box-reflect: below -20px linear-gradient(transparent, rgba(0, 0, 0, .2));
+    font-size: 2.2rem;
+}
+
+.waviy span {
+    font-family: 'Alfa Slab One', cursive;
+    position: relative;
+    display: inline-block;
+    color: #fff;
+    text-transform: uppercase;
+    animation: waviy 1s infinite;
+    animation-delay: calc(.1s * var(--i));
+}
+
+@keyframes waviy {
+    0%, 40%, 100% {
+        transform: translateY(0);
+    }
+    20% {
+        transform: translateY(-20px);
+    }
+}
+
+h1 {
+    color: #fff;
+    font-weight: 100;
+    margin-bottom: 50px;
+    margin-top: -20px;
+    font-size: 40px;
+}
+
+.card {
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+    border-radius: 15px;
+    padding: 20px;
+    text-align: center;
+    max-width: 600px;
+    width: 90%;
+    margin-bottom: 20px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease;
+}
+
+.card:hover {
+    transform: translateY(-10px);
+}
+
+.row {
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
+}
+
+.input, .result {
+    width: 100%;
+    margin-bottom: 15px;
+}
+
+.dropdown select {
+    width: 100%;
+    padding: 10px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    margin: 5px 0;
+}
+
+.input input, .result textarea {
+    width: calc(100% - 10px);
+    padding: 10px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    margin: 5px 0;
+    resize: none;
+}
+
+.buttons {
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+    gap:1.5rem;
+}
+
+button {
+    padding: 10px 20px;
+    border: none;
+    border-radius: 6px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 16px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    background-image: radial-gradient(100% 100% at 100% 0, #d7bb7e 0, #7e88d1 100%);
+    color: white;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    
+}
+
+button:focus {
+    outline: none;
+}
+
+button:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15);
+}
+
+button:active {
+    transform: translateY(2px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
# Description

This update enhances the color code converter tool by adding support for inter-conversion between various color code types, including RGB, RGBA, Hexadecimal, HSL, HSV, and CMYK. Users can now input color codes in any supported format and seamlessly convert them to other formats using the tool. 

Fixes:  #1354 


## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [ ] I have made this from my own
- [X] I have taken help from some online resourses 
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/113046759/8b42bbdc-38cf-459d-809a-e431fd6a3664

