### PR TITLE
Fix "NaN%" Output in Body Fat Percentage Calculator

### DIFF
--- a/Body Fat Percentage Extension/popup.html
+++ b/Body Fat Percentage Extension/popup.html
@@ -19,19 +19,19 @@
             </div>
             <div class="input-group">
                 <label for="neck">Neck Circumference (cm):</label>
-                <input type="number" id="neck" name="neck" required>
+                <input min="0" type="number" id="neck" name="neck" required>
             </div>
             <div class="input-group">
                 <label for="waist">Waist Circumference (cm):</label>
-                <input type="number" id="waist" name="waist" required>
+                <input min="0" type="number" id="waist" name="waist" required>
             </div>
             <div class="input-group" id="hipsGroup">
                 <label for="hips">Hips Circumference (cm):</label>
-                <input type="number" id="hips" name="hips">
+                <input min="0" type="number" id="hips" name="hips">
             </div>
             <div class="input-group">
                 <label for="height">Height (cm):</label>
-                <input type="number" id="height" name="height" required>
+                <input min="0" type="number" id="height" name="height" required>
             </div>
             <button type="button" onclick="calculateBodyFat()">Calculate</button>
         </form>

--- a/Body Fat Percentage Extension/popup.js
+++ b/Body Fat Percentage Extension/popup.js
@@ -12,8 +12,13 @@ function calculateBodyFat() {
         const hips = parseFloat(document.getElementById('hips').value);
         bodyFatPercentage = 163.205 * Math.log10(waist + hips - neck) - 97.684 * Math.log10(height) - 78.387;
     }
-
-    document.getElementById('result').innerText = `Body Fat Percentage: ${bodyFatPercentage.toFixed(2)}%`;
+    
+    if(isNaN(bodyFatPercentage)){
+        document.getElementById('result').innerText = 'Please enter valid input values';
+    }
+    else{   
+        document.getElementById('result').innerText = `Body Fat Percentage: ${bodyFatPercentage.toFixed(2)}%`;
+    }
 }
 
 // Show or hide the hips input based on gender


### PR DESCRIPTION
Fixed issue: #1615 

- Resolved the issue causing the Body Fat Percentage Calculator to return "NaN%" as the result.
- Improved handling of input values to ensure valid and accurate numerical results.

Fixes:  #1615 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

After making the changes:

https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/159511364/096834e5-1832-47c0-bbcb-c70204f49544

