### PR TITLE
Added Zapier extension

### DIFF
--- a/Zapier Extension/actions/download_file.js
+++ b/Zapier Extension/actions/download_file.js
@@ -1,0 +1,54 @@
+const { getCrowdinConnection } = require('./../_shared');
+const axios = require('axios')
+
+const { projectInputField, languageInputField, filesInputField } = require('./../_shared');
+
+async function execute(z, bundle) {
+    const { translationsApi, sourceFilesApi } = await getCrowdinConnection(z, bundle);
+
+    const project_id = bundle.inputData.project_id;
+    const file_id = bundle.inputData.file_id;
+    const language_id = bundle.inputData.language_id;
+
+    const translationsLink = await translationsApi.buildProjectFileTranslation(project_id, file_id, {
+        targetLanguageId: language_id
+    })
+
+    const file = (await sourceFilesApi.getFile(project_id, file_id)).data
+    const fileContent = (await axios.get(translationsLink.data.url)).data
+
+    return {
+        url: translationsLink.data.url,
+        name: file.name,
+        content: fileContent,
+    }
+}
+
+const uploadFile = {
+    noun: "Download Translated File",
+    display: {
+        hidden: false,
+        description: "Downloads the translated file.",
+        label: "Download Translated File"
+    },
+    key: "download_file",
+    operation: {
+        perform: execute,
+        inputFields: [
+            projectInputField,
+            filesInputField,
+            languageInputField],
+        sample: {
+            url: 'https://production-enterprise-importer.downloads.crowdin.com/992000002/2/14.xliff?response-content-disposition=attachment%253B%2520filename%253D%2522APP.xliff%2522&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIGJKLQV66ZXPMMEA%252F20190920%252Fus-east-1%252Fs3%252Faws4_request&X-Amz-Date=20190920T093121Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Signature=439ebd69a1b7e4c23e6d17891a491c94f832e0c82e4692dedb35a6cd1e624b62',
+            content: 'super super',
+            name: 'strings.xml'
+        },
+        outputFields: [
+            { key: 'url', label: 'URL' },
+            { key: 'name', label: 'File Name' },
+            { key: 'content', label: 'File Content' }
+        ],
+    },
+};
+
+module.exports = uploadFile;

--- a/Zapier Extension/actions/label_string.js
+++ b/Zapier Extension/actions/label_string.js
@@ -1,0 +1,61 @@
+const { projectInputField, labelsInputField, getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { labelsApi } = await getCrowdinConnection(z, bundle);
+
+  let request = {
+    stringIds: [bundle.inputData.string_id]
+  };
+
+  return (await labelsApi.assignLabelToString(bundle.inputData.project_id, bundle.inputData.label_id, request)).data[0]
+}
+
+module.exports = {
+  key: 'label_string',
+  noun: 'Label String',
+
+  display: {
+    label: 'Label String',
+    description: 'Assign a label to the string'
+  },
+
+  operation: {
+    perform,
+
+    inputFields: [
+      projectInputField,
+      labelsInputField, {
+        key: 'string_id',
+        label: 'String ID',
+        required: true,
+        type: 'integer'
+      }
+    ],
+
+    sample: {
+      "data": {
+        "id": 2814,
+        "projectId": 2,
+        "fileId": 48,
+        "branchId": 12,
+        "directoryId": 13,
+        "identifier": "name",
+        "text": "Not all videos are shown to users. See more",
+        "type": "text",
+        "context": "shown on main page",
+        "maxLength": 35,
+        "isHidden": false,
+        "isDuplicate": true,
+        "masterStringId": 1,
+        "revision": 1,
+        "hasPlurals": false,
+        "isIcu": false,
+        "labelIds": [
+          3
+        ],
+        "createdAt": "2019-09-20T12:43:57+00:00",
+        "updatedAt": "2019-09-20T13:24:01+00:00"
+      }
+    }
+  }
+}

--- a/Zapier Extension/actions/project_status.js
+++ b/Zapier Extension/actions/project_status.js
@@ -1,0 +1,61 @@
+const { projectInputField, getCrowdinConnection } = require('./../_shared');
+
+const perform = async (z, bundle) => {
+  const { translationStatusApi, languagesApi } = await getCrowdinConnection(z, bundle);
+
+  const languages = (await languagesApi.withFetchAll().listSupportedLanguages()).data
+
+  const status = (await translationStatusApi.withFetchAll().getProjectProgress(bundle.inputData.project_id)).data
+
+  let result = {}
+
+  status.forEach((languageProgress) => {
+    let languageName = (languages.find(obj => obj.data.id == languageProgress.data.languageId)).data.name
+
+    result[languageName] = {
+      ...languageProgress.data,
+      languageName: languageName
+    }
+  })
+
+  return result
+};
+
+module.exports = {
+  key: 'project_status',
+  noun: 'Translation Progress',
+
+  display: {
+    label: 'Translation Progress',
+    description: 'Get project languages translation progress.'
+  },
+
+  operation: {
+    perform,
+
+    inputFields: [
+      projectInputField
+    ],
+
+    sample: {
+      "data": [{
+        "data": {
+          "words": {
+            "total": 7249,
+            "translated": 3651,
+            "approved": 3637
+          },
+          "phrases": {
+            "total": 3041,
+            "translated": 2631,
+            "approved": 2622
+          },
+          "translationProgress": 86,
+          "approvalProgress": 86,
+          "languageId": "uk",
+          "languageName": "Ukrainian"
+        }
+      }]
+    }
+  }
+};

--- a/Zapier Extension/actions/remove_string_label.js
+++ b/Zapier Extension/actions/remove_string_label.js
@@ -1,0 +1,56 @@
+const { projectInputField, labelsInputField, getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { labelsApi } = await getCrowdinConnection(z, bundle);
+  return (await labelsApi.unassignLabelFromString(bundle.inputData.project_id, bundle.inputData.label_id, [bundle.inputData.string_id])).data[0]
+}
+
+module.exports = {
+  key: 'remove_label',
+  noun: 'Remove Label',
+
+  display: {
+    label: 'Remove Label From String',
+    description: 'Unassign the label from the string'
+  },
+
+  operation: {
+    perform,
+
+    inputFields: [
+      projectInputField,
+      labelsInputField, {
+        key: 'string_id',
+        label: 'String ID',
+        required: true,
+        type: 'integer'
+      }
+    ],
+
+    sample: {
+      "data": {
+        "id": 2814,
+        "projectId": 2,
+        "fileId": 48,
+        "branchId": 12,
+        "directoryId": 13,
+        "identifier": "name",
+        "text": "Not all videos are shown to users. See more",
+        "type": "text",
+        "context": "shown on main page",
+        "maxLength": 35,
+        "isHidden": false,
+        "isDuplicate": true,
+        "masterStringId": 1,
+        "revision": 1,
+        "hasPlurals": false,
+        "isIcu": false,
+        "labelIds": [
+          3
+        ],
+        "createdAt": "2019-09-20T12:43:57+00:00",
+        "updatedAt": "2019-09-20T13:24:01+00:00"
+      }
+    }
+  }
+}

--- a/Zapier Extension/actions/resolve_issue.js
+++ b/Zapier Extension/actions/resolve_issue.js
@@ -1,0 +1,74 @@
+const { issueTypeField, issueStatusField, commentTypeField, languageInputField, projectInputField, getCrowdinConnection } = require('./../_shared');
+
+const perform = async (z, bundle) => {
+  const { stringCommentsApi } = await getCrowdinConnection(z, bundle);
+
+  let request = [{
+    value: 'resolved',
+    op: 'replace',
+    path: `/issueStatus`
+  }];
+
+  return (await stringCommentsApi.editStringComment(bundle.inputData.project_id, bundle.inputData.comment_id, request)).data
+};
+
+module.exports = {
+  key: 'resolve_issue',
+  noun: 'Resolve Issue',
+
+  display: {
+    label: 'Resolve Issue',
+    description: 'Set the issue resolved.'
+  },
+
+  operation: {
+    perform,
+
+    inputFields: [
+      projectInputField,
+      {
+        key: 'comment_id',
+        label: 'Comment ID',
+        required: true,
+        type: 'integer'
+      }
+    ],
+
+    sample: {
+      "data": {
+        "id": 2,
+        "text": "@BeMyEyes  Please provide more details on where the text will be used",
+        "userId": 6,
+        "stringId": 742,
+        "user": {
+          "id": 12,
+          "username": "john_smith",
+          "fullName": "John Smith",
+          "avatarUrl": ""
+        },
+        "string": {
+          "id": 123,
+          "text": "HTML page example",
+          "type": "text",
+          "hasPlurals": false,
+          "isIcu": false,
+          "context": "Document Title\\r\\nXPath: /html/head/title",
+          "fileId": 22
+        },
+        "languageId": "bg",
+        "type": "issue",
+        "issueType": "source_mistake",
+        "issueStatus": "unresolved",
+        "resolverId": 6,
+        "resolver": {
+          "id": 12,
+          "username": "john_smith",
+          "fullName": "John Smith",
+          "avatarUrl": ""
+        },
+        "resolvedAt": "2019-09-20T11:05:24+00:00",
+        "createdAt": "2019-09-20T11:05:24+00:00"
+      }
+    }
+  }
+};

--- a/Zapier Extension/actions/translate_mt.js
+++ b/Zapier Extension/actions/translate_mt.js
@@ -1,0 +1,55 @@
+const { languageInputField, mtInputField, getCrowdinConnection } = require('./../_shared');
+
+async function execute(z, bundle) {
+    const { machineTranslationApi } = await getCrowdinConnection(z, bundle);
+
+    const data = (await machineTranslationApi.translate(bundle.inputData.mt_id, {
+        languageRecognitionProvider: 'engine',
+        sourceLanguageId: bundle.inputData.source_language_id,
+        targetLanguageId: bundle.inputData.target_language_id,
+        strings: bundle.inputData.strings
+    })).data
+
+    //array to object as Zapier likes it more
+    data.strings = data.strings.reduce(function (result, item, index, array) {
+        result[`string_${index}`] = item;
+        return result;
+    }, {})
+
+    data.translations = data.translations.reduce(function (result, item, index, array) {
+        result[`string_${index}`] = item;
+        return result;
+    }, {})
+
+    return data
+}
+
+module.exports = {
+    noun: "Translation",
+    display: {
+        hidden: false,
+        description: "Auto detect source language and translate with selected MT engine.",
+        label: "Translate via Machine Translation"
+    },
+    key: "translate_mt",
+    operation: {
+        perform: execute,
+        inputFields: [
+            mtInputField,
+            { ...languageInputField, label: 'Source Language (leave empty to detect automatically)', key: 'source_language_id', required: false },
+            { ...languageInputField, label: 'Target Language', key: 'target_language_id' },
+            { type: 'text', list: true, key: 'strings', required: true, label: 'Text To Translate' }
+        ],
+        sample: {
+            "languageRecognitionProvider": "crowdin",
+            "sourceLanguageId": "en",
+            "targetLanguageId": "de",
+            "strings": [
+                "Welcome!",
+                "Save as...",
+                "View",
+                "About..."
+            ]
+        }
+    },
+};

--- a/Zapier Extension/actions/upload_file.js
+++ b/Zapier Extension/actions/upload_file.js
@@ -1,0 +1,102 @@
+const { projectInputField, directoriesInputField, labelsInputField, getCrowdinConnection } = require('./../_shared');
+
+async function execute(z, bundle) {
+    const { sourceFilesApi, uploadStorageApi } = await getCrowdinConnection(z, bundle);
+
+    const project_id = bundle.inputData.project_id;
+    const file_name = bundle.inputData.file_name;
+    const file_url = bundle.inputData.file_url;
+    const file_contents = bundle.inputData.file_contents;
+
+    let contents = ''
+    if (file_url && file_url.length) {
+        contents = (await z.request({
+            url: file_url,
+            method: 'GET'
+        })).content;
+    }
+
+    if (file_contents && file_contents.length > 0) {
+        contents = file_contents;
+    }
+
+    const sourceFileStorageId = (await uploadStorageApi.addStorage(file_name, contents)).data.id;
+
+    const existingFile = (await sourceFilesApi.withFetchAll().listProjectFiles(project_id)).data.find((file) => (file.data.name == file_name));
+
+    let fileResponse;
+
+    if (existingFile) {
+        fileResponse = (await sourceFilesApi.updateOrRestoreFile(project_id, existingFile.data.id, {
+            storageId: sourceFileStorageId,
+            attachLabelIds: bundle.inputData.label_id
+        })).data;
+    } else {
+        let addFileRequest = {
+            storageId: sourceFileStorageId,
+            name: file_name,
+            attachLabelIds: bundle.inputData.label_id
+        }
+
+        bundle.inputData.directory_id && (addFileRequest.directoryId = bundle.inputData.directory_id);
+        bundle.inputData.title && (addFileRequest.title = bundle.inputData.title);
+
+        fileResponse = (await sourceFilesApi.createFile(project_id, addFileRequest)).data;
+    }
+
+    return fileResponse;
+}
+
+const uploadFile = {
+    noun: "File",
+    display: {
+        hidden: false,
+        description: "Uploads a file into Crowdin project.",
+        label: "Create or Update a File"
+    },
+    key: "upload_file",
+    operation: {
+        perform: execute,
+        inputFields: [
+            projectInputField, {
+                required: true,
+                label: "File Name",
+                helpText: "Name of the file.",
+                key: "file_name",
+                type: "string",
+            }, {
+                required: false,
+                label: "File Title",
+                helpText: "How the file will be shown to translators.",
+                key: "title",
+                type: "string",
+            }, {
+                required: false,
+                label: "File URL",
+                helpText: "Either URL or file contents is required.",
+                key: "file_url",
+                type: "string",
+            }, {
+                required: false,
+                label: "File Contents",
+                helpText: "Either URL or file contents is required.",
+                key: "file_contents",
+                type: "string",
+            }, {
+                ...directoriesInputField,
+                required: false,
+                label: 'Parent Directory ID',
+            }, {
+                ...labelsInputField, required: false, list: true
+            }],
+        sample: {
+            id: '1'
+        },
+        outputFields: [
+            { key: 'id', label: 'ID' },
+            { key: 'name', label: 'File Name' }
+        ],
+    },
+};
+
+module.exports = uploadFile;

--- a/Zapier Extension/actions/upload_screenshot.js
+++ b/Zapier Extension/actions/upload_screenshot.js
@@ -1,0 +1,116 @@
+const { getCrowdinConnection, projectInputField } = require('./../_shared');
+const axios = require('axios')
+
+async function execute(z, bundle) {
+    const { screenshotsApi, uploadStorageApi } = await getCrowdinConnection(z, bundle);
+
+    const project_id = bundle.inputData.project_id;
+    const file_name = bundle.inputData.file_name;
+    const file_url = bundle.inputData.file_url;
+    const file_contents = bundle.inputData.file_contents;
+    const auto_tag = !!bundle.inputData.auto_tag;
+
+    let contents = ''
+    if (file_url && file_url.length) {
+        contents = Buffer.from((await axios.get(file_url, { responseType: 'arraybuffer' })).data, "utf-8")
+    }
+
+    if (file_contents && file_contents.length > 0) {
+        contents = Buffer.from(file_contents, "utf-8")
+    }
+
+    const sourceFileStorageId = (await uploadStorageApi.addStorage(file_name, contents)).data.id;
+
+    const existingScreenshot = (await screenshotsApi.withFetchAll().listScreenshots(project_id)).data.find((file) => (file.data.name == file_name));
+
+    let fileResponse;
+
+    if (existingScreenshot) {
+        fileResponse = (await screenshotsApi.updateScreenshot(project_id, existingScreenshot.data.id, {
+            storageId: sourceFileStorageId,
+            name: file_name
+        })).data;
+    } else {
+        fileResponse = (await screenshotsApi.addScreenshot(project_id, {
+            storageId: sourceFileStorageId,
+            name: file_name,
+            autoTag: auto_tag
+        })).data;
+    }
+
+    return fileResponse;
+}
+
+const uploadFile = {
+    noun: "Upload Screenshot",
+    display: {
+        hidden: false,
+        description: "Adds a screenshot to Crowdin project and tags it automatically (optional).",
+        label: "Upload Screenshot"
+    },
+    key: "upload_screenshot",
+    operation: {
+        perform: execute,
+        inputFields: [
+            projectInputField, {
+                required: true,
+                label: "Screenshot Name",
+                helpText: "Name of the screenshot.",
+                key: "file_name",
+                type: "string",
+            }, {
+                required: true,
+                label: "Auto Tag",
+                helpText: "Whether Crowdin should try to find strings on the screenshot and link it with proper strings.",
+                key: "auto_tag",
+                type: "boolean",
+            }, {
+                required: false,
+                label: "Screenshot URL",
+                helpText: "URL of the screenshot to upload. Use the File Contents field if there's no image URL in this Zap.",
+                key: "file_url",
+                type: "string",
+            }, {
+                required: false,
+                label: "Image Contents",
+                helpText: "Binary data of the image. Use Screenshot URL if there's no image data in this Zap.",
+                key: "file_contents",
+                type: "string",
+            }],
+        sample: {
+            "data": {
+                "id": 2,
+                "userId": 6,
+                "url": "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIGJKLQV66ZXPMMEA%2F20190923%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190923T093016Z&X-Amz-SignedHeaders=host&X-Amz-Expires=120&X-Amz-Signature=8df06f57594f7d1804b7c037629f6916224415e9b935c4f6619fbe002fb25e73",
+                "name": "translate_with_siri.jpg",
+                "size": {
+                    "width": 267,
+                    "height": 176
+                },
+                "tagsCount": 0,
+                "tags": [
+                    {
+                        "id": 98,
+                        "screenshotId": 2,
+                        "stringId": 2822,
+                        "position": {
+                            "x": 474,
+                            "y": 147,
+                            "width": 490,
+                            "height": 99
+                        },
+                        "createdAt": "2019-09-23T09:35:31+00:00"
+                    }
+                ],
+                "createdAt": "2019-09-23T09:29:19+00:00",
+                "updatedAt": "2019-09-23T09:29:19+00:00"
+            }
+        },
+        outputFields: [
+            { key: 'id', label: 'ID' },
+            { key: 'name', label: 'File Name' }
+        ],
+    },
+};
+
+module.exports = uploadFile;

--- a/Zapier Extension/fields/list_files_dropdown.js
+++ b/Zapier Extension/fields/list_files_dropdown.js
@@ -1,0 +1,18 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { sourceFilesApi } = await getCrowdinConnection(z, bundle);
+
+  return (await sourceFilesApi.withFetchAll().listProjectFiles(bundle.inputData.project_id)).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_project_files',
+  noun: 'File',
+  display: {
+    label: 'List Files',
+    description: 'Returns a list of project files.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_labels_dropdown.js
+++ b/Zapier Extension/fields/list_labels_dropdown.js
@@ -1,0 +1,18 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { labelsApi } = await getCrowdinConnection(z, bundle);
+
+  return (await labelsApi.withFetchAll().listLabels(bundle.inputData.project_id)).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_project_labels',
+  noun: 'Label',
+  display: {
+    label: 'List Labels',
+    description: 'Returns a list of project labels.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_languages_dropdown.js
+++ b/Zapier Extension/fields/list_languages_dropdown.js
@@ -1,0 +1,17 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { languagesApi } = await getCrowdinConnection(z, bundle);
+  return (await languagesApi.withFetchAll().listSupportedLanguages()).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_languages',
+  noun: 'Language',
+  display: {
+    label: 'List Languages',
+    description: 'Returns a list of Crowdin languages.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_mts_dropdown.js
+++ b/Zapier Extension/fields/list_mts_dropdown.js
@@ -1,0 +1,18 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { machineTranslationApi } = await getCrowdinConnection(z, bundle);
+
+  return (await machineTranslationApi.withFetchAll().listMts()).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_mts',
+  noun: 'Machine Translation Engine',
+  display: {
+    label: 'List Machine Translation Engines',
+    description: 'Returns a list of machine translation engines.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_project_directories_dropdown.js
+++ b/Zapier Extension/fields/list_project_directories_dropdown.js
@@ -1,0 +1,20 @@
+const { projectInputField, getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { sourceFilesApi } = await getCrowdinConnection(z, bundle);
+  return (await sourceFilesApi.withFetchAll().listProjectDirectories(bundle.inputData.project_id, {})).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: {
+    inputFields: [projectInputField],
+    perform: perform
+  },
+  key: 'list_project_directories',
+  noun: 'Directory',
+  display: {
+    label: 'List Directories',
+    description: 'Returns a list of project directories.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_project_members_dropdown.js
+++ b/Zapier Extension/fields/list_project_members_dropdown.js
@@ -1,0 +1,18 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { usersApi } = await getCrowdinConnection(z, bundle);
+
+  return (await usersApi.listProjectMembers(bundle.inputData.project_id)).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_project_members',
+  noun: 'Project Members',
+  display: {
+    label: 'List Project Members',
+    description: 'Returns a list of project members.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_project_workflow_steps_dropdown.js
+++ b/Zapier Extension/fields/list_project_workflow_steps_dropdown.js
@@ -1,0 +1,23 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  //it's crowdin.com
+  if (!bundle.authData.domain) {
+    return [{ id: 0, title: 'Default for crowdin.com' }]
+  }
+
+  const { workflowsApi } = await getCrowdinConnection(z, bundle);
+
+  return (await workflowsApi.listWorkflowSteps(bundle.inputData.project_id)).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_project_workflow_steps',
+  noun: 'Workflow Step',
+  display: {
+    label: 'List Project Workflow Steps',
+    description: 'Returns a list of project workflow steps.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_projects_dropdown.js
+++ b/Zapier Extension/fields/list_projects_dropdown.js
@@ -1,0 +1,20 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  const { projectsGroupsApi } = await getCrowdinConnection(z, bundle);
+
+  return (await projectsGroupsApi.withFetchAll().listProjects({
+    hasManagerAccess: 1
+  })).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_projects',
+  noun: 'Project',
+  display: {
+    label: 'List Projects',
+    description: 'Returns a list of user projects.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_vendors_dropdown.js
+++ b/Zapier Extension/fields/list_vendors_dropdown.js
@@ -1,0 +1,23 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  //it's crowdin.com
+  if (!bundle.authData.domain) {
+    return [{ id: 0, title: 'Default for crowdin.com' }]
+  }
+
+  const { vendorsApi } = await getCrowdinConnection(z, bundle);
+
+  return (await vendorsApi.withFetchAll().listVendors()).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_vendors',
+  noun: 'Vendor',
+  display: {
+    label: 'List Vendors',
+    description: 'Returns a list of organization vendors.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/fields/list_workflows.js
+++ b/Zapier Extension/fields/list_workflows.js
@@ -1,0 +1,23 @@
+const { getCrowdinConnection } = require('../_shared');
+
+const perform = async (z, bundle) => {
+  //it's crowdin.com
+  if (!bundle.authData.domain) {
+    return [{ id: 0, title: 'Default for crowdin.com' }]
+  }
+
+  const { workflowsApi } = await getCrowdinConnection(z, bundle);
+
+  return (await workflowsApi.withFetchAll().listWorkflowTemplates()).data.map((obj) => obj.data)
+};
+
+module.exports = {
+  operation: { perform: perform },
+  key: 'list_workflows',
+  noun: 'Workflow',
+  display: {
+    label: 'List Workflows',
+    description: 'Returns a list of user workflows.',
+    hidden: true,
+  }
+}

--- a/Zapier Extension/index.js
+++ b/Zapier Extension/index.js
@@ -1,0 +1,108 @@
+const authentication = require('./authentication')
+
+//Actions
+const uploadFileAction = require('./actions/upload_file')
+const downloadFileAction = require('./actions/download_file')
+const uploadScreenshotAction = require('./actions/upload_screenshot')
+const createResolveIssueAction = require("./actions/resolve_issue")
+const labelStringAction = require("./actions/label_string")
+const removeStringLabelAction = require("./actions/remove_string_label")
+const translateMtAction = require("./actions/translate_mt")
+const projectStatusAction = require('./actions/project_status')
+
+//Searches
+const findLanguageSearch = require('./searches/find_language')
+const findFileSearch = require('./searches/find_file')
+
+//Fields
+const listProjectsDropdown = require('./fields/list_projects_dropdown')
+const listLanguagesDropdown = require('./fields/list_languages_dropdown')
+const listProjectDirectoriesDropdown = require('./fields/list_project_directories_dropdown')
+const listWorkflowsDropdown = require('./fields/list_workflows')
+const listFilesDropdown = require('./fields/list_files_dropdown')
+const listLabelsDropdown = require('./fields/list_labels_dropdown')
+const listProjectWorkflowStepsDropdown = require('./fields/list_project_workflow_steps_dropdown')
+const listProjectMembersDropdown = require('./fields/list_project_members_dropdown')
+const listMtsDropdown = require('./fields/list_mts_dropdown')
+const listVendorsDropdown = require('./fields/list_vendors_dropdown')
+
+//Triggers
+const projectTranslatedTrigger = require('./triggers/project_translated')
+const projectApprovedTrigger = require('./triggers/project_approved')
+const fileTranslatedTrigger = require('./triggers/file_translated')
+const fileApprovedTrigger = require('./triggers/file_approved')
+const fileAddedTrigger = require('./triggers/file_added')
+const fileUpdatedTrigger = require('./triggers/file_updated')
+const fileRevertedTrigger = require('./triggers/file_reverted')
+const fileDeletedTrigger = require('./triggers/file_deleted')
+const commentCreatedTrigger = require('./triggers/comment_created')
+const commentUpdatedTrigger = require('./triggers/comment_updated')
+const commentDeletedTrigger = require('./triggers/comment_deleted')
+const commentRestoredTrigger = require('./triggers/comment_restored')
+
+//Resources
+const directoryResource = require("./resources/directory")
+const commentResource = require("./resources/comment")
+const labelResource = require("./resources/label")
+const projectResource = require("./resources/project")
+const stringResource = require("./resources/string")
+const taskResource = require("./resources/task")
+
+module.exports = {
+  version: require('./package.json').version,
+  platformVersion: require('zapier-platform-core').version,
+  authentication: authentication,
+
+  creates: {
+    [uploadFileAction.key]: uploadFileAction,
+    [downloadFileAction.key]: downloadFileAction,
+    [uploadScreenshotAction.key]: uploadScreenshotAction,
+    [createResolveIssueAction.key]: createResolveIssueAction,
+    [labelStringAction.key]: labelStringAction,
+    [removeStringLabelAction.key]: removeStringLabelAction,
+    [translateMtAction.key]: translateMtAction,
+    [projectStatusAction.key]: projectStatusAction,
+  },
+
+  flags: { skipThrowForStatus: true },
+
+  searches: {
+    [findLanguageSearch.key]: findLanguageSearch,
+    [findFileSearch.key]: findFileSearch
+  },
+
+  triggers: {
+    [listProjectsDropdown.key]: listProjectsDropdown,
+    [listLanguagesDropdown.key]: listLanguagesDropdown,
+    [listProjectDirectoriesDropdown.key]: listProjectDirectoriesDropdown,
+    [listWorkflowsDropdown.key]: listWorkflowsDropdown,
+    [listFilesDropdown.key]: listFilesDropdown,
+    [listLabelsDropdown.key]: listLabelsDropdown,
+    [listProjectWorkflowStepsDropdown.key]: listProjectWorkflowStepsDropdown,
+    [listProjectMembersDropdown.key]: listProjectMembersDropdown,
+    [listMtsDropdown.key]: listMtsDropdown,
+    [listVendorsDropdown.key]: listVendorsDropdown,
+
+    [projectTranslatedTrigger.key]: projectTranslatedTrigger,
+    [projectApprovedTrigger.key]: projectApprovedTrigger,
+    [fileTranslatedTrigger.key]: fileTranslatedTrigger,
+    [fileApprovedTrigger.key]: fileApprovedTrigger,
+    [fileAddedTrigger.key]: fileAddedTrigger,
+    [fileUpdatedTrigger.key]: fileUpdatedTrigger,
+    [fileRevertedTrigger.key]: fileRevertedTrigger,
+    [fileDeletedTrigger.key]: fileDeletedTrigger,
+    [commentCreatedTrigger.key]: commentCreatedTrigger,
+    [commentUpdatedTrigger.key]: commentUpdatedTrigger,
+    [commentRestoredTrigger.key]: commentRestoredTrigger,
+    [commentDeletedTrigger.key]: commentDeletedTrigger,
+  },
+
+  resources: {
+    [directoryResource.key]: directoryResource,
+    [commentResource.key]: commentResource,
+    [labelResource.key]: labelResource,
+    [projectResource.key]: projectResource,
+    [stringResource.key]: stringResource,
+    [taskResource.key]: taskResource
+  }
+}

--- a/Zapier Extension/resources/comment.js
+++ b/Zapier Extension/resources/comment.js
@@ -1,0 +1,86 @@
+const { issueTypeField, issueStatusField, commentTypeField, languageInputField, projectInputField, getCrowdinConnection } = require('./../_shared');
+
+const performCreate = async (z, bundle) => {
+  const { stringCommentsApi } = await getCrowdinConnection(z, bundle);
+
+  let request = {};
+  request.stringId = bundle.inputData.string_id;
+  request.text = bundle.inputData.text;
+  request.targetLanguageId = bundle.inputData.language_id;
+  bundle.inputData.type && (request.type = bundle.inputData.type);
+  bundle.inputData.issue_type && (request.issueType = bundle.inputData.issue_type);
+
+  if (bundle.inputData.type == 'comment') {
+    delete request.issueType; //regular comments can't have issueType
+  }
+
+  return (await stringCommentsApi.addStringComment(bundle.inputData.project_id, request)).data
+}
+
+module.exports = {
+  key: 'comment',
+  noun: 'Comment',
+
+  create: {
+    display: {
+      label: 'Create Comment',
+      description: 'Creates a new comment or issue.'
+    },
+    operation: {
+      inputFields: [
+        projectInputField, {
+          required: true,
+          label: "Text",
+          helpText: "Comment itself",
+          key: "text",
+          type: "string",
+        }, {
+          required: true,
+          label: "String ID",
+          helpText: "String ID (can be found in string events from Crowdin)",
+          key: "string_id",
+          type: "integer",
+        },
+        languageInputField,
+        commentTypeField,
+        issueTypeField
+      ],
+      perform: performCreate
+    },
+  },
+
+  sample: {
+    "id": 2,
+    "text": "@BeMyEyes  Please provide more details on where the text will be used",
+    "userId": 6,
+    "stringId": 742,
+    "user": {
+      "id": 12,
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    },
+    "string": {
+      "id": 123,
+      "text": "HTML page example",
+      "type": "text",
+      "hasPlurals": false,
+      "isIcu": false,
+      "context": "Document Title\\r\\nXPath: /html/head/title",
+      "fileId": 22
+    },
+    "languageId": "bg",
+    "type": "issue",
+    "issueType": "source_mistake",
+    "issueStatus": "unresolved",
+    "resolverId": 6,
+    "resolver": {
+      "id": 12,
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    },
+    "resolvedAt": "2019-09-20T11:05:24+00:00",
+    "createdAt": "2019-09-20T11:05:24+00:00"
+  }
+};

--- a/Zapier Extension/resources/directory.js
+++ b/Zapier Extension/resources/directory.js
@@ -1,0 +1,112 @@
+const { projectInputField, directoriesInputField, getCrowdinConnection } = require('./../_shared');
+
+const performList = async (z, bundle) => {
+  const { sourceFilesApi } = await getCrowdinConnection(z, bundle);
+
+  let request = {};
+  bundle.inputData.directory_id && (request.directoryId = bundle.inputData.directory_id);
+
+  return (await sourceFilesApi.withFetchAll().listProjectDirectories(bundle.inputData.project_id, request)).data.map((obj) => obj.data)
+}
+
+const performSearch = async (z, bundle) => {
+  const { sourceFilesApi } = await getCrowdinConnection(z, bundle);
+
+  const directories = (await sourceFilesApi.withFetchAll().listProjectDirectories(bundle.inputData.project_id)).data;
+
+  const search = directories.map((obj) => obj.data).find((dir) => dir.name == bundle.inputData.name);
+
+  if (!directories || !search) {
+    return []
+  } else {
+    return [search]
+  }
+}
+
+const performCreate = async (z, bundle) => {
+  const { sourceFilesApi } = await getCrowdinConnection(z, bundle);
+
+  let request = {
+    name: bundle.inputData.name
+  }
+
+  bundle.inputData.priority && (request.priority = bundle.inputData.priority);
+  bundle.inputData.directory_id && (request.directoryId = bundle.inputData.directory_id);
+  bundle.inputData.title && (request.title = bundle.inputData.title);
+
+  return (await sourceFilesApi.createDirectory(bundle.inputData.project_id, request)).data
+};
+
+module.exports = {
+  key: 'directory',
+  noun: 'Directory',
+
+  list: {
+    display: {
+      label: 'New Directory',
+      description: 'Triggers when new directory is created.',
+    },
+    operation: {
+      perform: performList,
+      inputFields: [projectInputField, {
+        ...directoriesInputField,
+        required: false,
+        label: 'Parent Directory ID',
+      }]
+    }
+  },
+
+  search: {
+    display: {
+      label: 'Find Directory',
+      description: 'Finds a directory.',
+    },
+    operation: {
+      inputFields: [projectInputField,
+        { key: 'name', required: true }
+      ],
+      perform: performSearch
+    },
+  },
+
+  create: {
+    display: {
+      label: 'Create Directory',
+      description: 'Creates a new directory.'
+    },
+    operation: {
+      inputFields: [
+        projectInputField,
+        { key: 'name', required: true }, {
+          ...directoriesInputField,
+          required: false,
+          label: 'Parent Directory ID',
+        }, { key: 'title', required: false }, {
+          label: 'Priority',
+          key: 'priority',
+          required: false,
+          choices: [
+            { value: 'low', label: 'Low', sample: 'low' },
+            { value: 'normal', label: 'Normal', sample: 'normal' },
+            { value: 'high', label: 'High', sample: 'high' }
+          ],
+          altersDynamicFields: true,
+        }
+      ],
+      perform: performCreate
+    },
+  },
+
+  sample: {
+    "id": 4,
+    "projectId": 2,
+    "branchId": 34,
+    "directoryId": null,
+    "name": "main",
+    "title": "<Description materials>",
+    "exportPattern": "/localization/%locale%/%file_name%",
+    "priority": "normal",
+    "createdAt": "2019-09-19T14:14:00+00:00",
+    "updatedAt": "2019-09-19T14:14:00+00:00"
+  }
+}

--- a/Zapier Extension/resources/label.js
+++ b/Zapier Extension/resources/label.js
@@ -1,0 +1,70 @@
+const { projectInputField, getCrowdinConnection } = require('./../_shared');
+
+const performList = async (z, bundle) => {
+  const { labelsApi } = await getCrowdinConnection(z, bundle);
+  return (await labelsApi.withFetchAll().listLabels(bundle.inputData.project_id)).data.map((obj) => obj.data).map((obj) => ({ ...obj, id: obj.title }))
+};
+
+const performSearch = async (z, bundle) => {
+  const { labelsApi } = await getCrowdinConnection(z, bundle);
+
+  const result = (await labelsApi.withFetchAll().listLabels(bundle.inputData.project_id)).data.map((obj) => obj.data).find((label) => label.title == bundle.inputData.title);
+
+  return result || []
+};
+
+const performCreate = async (z, bundle) => {
+  const { labelsApi } = await getCrowdinConnection(z, bundle);
+
+  let request = {
+    title: bundle.inputData.title
+  };
+
+  return (await labelsApi.addLabel(bundle.inputData.project_id, request)).data
+};
+
+module.exports = {
+  key: 'label',
+  noun: 'Label',
+
+  list: {
+    display: {
+      label: 'New Label',
+      description: 'Triggers when new label is created.'
+    },
+    operation: {
+      perform: performList,
+      inputFields: [projectInputField]
+    }
+  },
+
+  search: {
+    display: {
+      label: 'Find Label',
+      description: 'Find label.'
+    },
+    operation: {
+      perform: performSearch,
+      inputFields: [projectInputField, { key: 'title', required: true }]
+    }
+  },
+
+  create: {
+    display: {
+      label: 'Create Label',
+      description: 'Creates a new label.'
+    },
+    operation: {
+      inputFields: [
+        projectInputField,
+        { key: 'title', required: true }
+      ],
+      perform: performCreate
+    },
+  },
+
+  sample: {
+    "id": 34,
+    "title": "main"
+  }
+}

--- a/Zapier Extension/resources/project.js
+++ b/Zapier Extension/resources/project.js
@@ -1,0 +1,136 @@
+const { workflowInputField, languageInputField, projectInputField, vendorInputField, getCrowdinConnection } = require('./../_shared');
+
+const performList = async (z, bundle) => {
+  const { projectsGroupsApi } = await getCrowdinConnection(z, bundle);
+
+  return (await projectsGroupsApi.withFetchAll().listProjects()).data.map((obj) => obj.data)
+};
+
+const performSearch = async (z, bundle) => {
+  const { projectsGroupsApi } = await getCrowdinConnection(z, bundle);
+
+  const data = (await projectsGroupsApi.withFetchAll().listProjects()).data.map((obj) => obj.data)
+
+  if (bundle.inputData.project_id) {
+    return [data.find((project) => project.id == bundle.inputData.project_id)]
+  } else if (bundle.inputData.name) {
+    return [data.find((project) => project.name == bundle.inputData.name)]
+  } else {
+    return []
+  }
+};
+
+const performCreate = async (z, bundle) => {
+  const { projectsGroupsApi } = await getCrowdinConnection(z, bundle);
+
+  let request = {
+    name: bundle.inputData.name,
+    sourceLanguageId: bundle.inputData.language_id,
+    targetLanguageIds: bundle.inputData.target_languages
+  }
+
+  //it's Crowdin Enterprise
+  if (bundle.authData.domain) {
+    request.templateId = bundle.inputData.workflow_id
+
+    bundle.inputData.vendor_id && (request.vendorId = bundle.inputData.vendor_id)
+  }
+
+  bundle.inputData.description && (request.description = bundle.inputData.description)
+
+  return (await projectsGroupsApi.addProject(request)).data
+};
+
+module.exports = {
+  key: 'project',
+  noun: 'Project',
+
+  list: {
+    display: {
+      label: 'New Project',
+      description: 'Triggers when a new project is created.'
+    },
+    operation: {
+      perform: performList,
+      inputFields: []
+    }
+  },
+
+  search: {
+    display: {
+      label: 'Find Project',
+      description: 'Finds a project by id or name.'
+    },
+    operation: {
+      inputFields: [
+        { ...projectInputField, required: false },
+        { key: 'name', required: false }
+      ],
+      perform: performSearch
+    },
+  },
+
+  create: {
+    display: {
+      label: 'Create Project',
+      description: 'Creates a new project.'
+    },
+    operation: {
+      inputFields: [
+        { key: 'name', required: true },
+        languageInputField,
+        workflowInputField,
+        { ...languageInputField, list: true, label: 'Target Languages', key: 'target_languages' },
+        { ...vendorInputField, label: 'Vendor ID (for Enterprise only, for workflows that require the Vendor ID only)', required: false },
+        { key: 'description' }
+      ],
+      perform: performCreate
+    },
+  },
+
+  sample: {
+    "id": 8,
+    "groupId": 4,
+    "userId": 6,
+    "sourceLanguageId": "en",
+    "targetLanguageIds": [
+      "es"
+    ],
+    "name": "Knowledge Base",
+    "identifier": "1f198a4e907688bc65834a6d5a6000c3",
+    "description": "Vault of all terms and their explanation",
+    "logo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAGm0lEQVR4nO3cWVCVdRjH8R+HTQQR93BJo1Jz1MrRSS21JDUNRWUxMabVpvXcNuNdl100U2qNuQ+KIiCCCIqYoSPkbiippCKiuBDKvp6FLmzG8Pxf1vO858D7+1z6vA7PMN85Oud//scj0rymBUROZnL1AtQ7MSwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEiEl6sXkLThu2+Vfx6Xmom8C5fEfu7bM6Yh8p25ytmjyip8v3knqmpqxX6+O+ArlpNNmzQBy+e/pZzV1tXjx7g9vT4qgGE51fiQ0fhg6SKYTB4Os8amZqyPT0bZwwoXbKY/huUko4KH4fP3lsPLy9NhZrXa8OuefSguveeCzVyDYTnBkIFB+Ob9KPTx9XGY2e0t2L4vA1duFOu/mAsxrG7q598X5tgVCAzwV84TDx7B2YIrOm/legyrG3x9vGGOjcaQgUHKecaxXOScPq/zVu6BYXWRyeSBL1ZGYFTwMOX8+Nk/kX70hM5buQ+G1UUfRyzG+JDRytn5y4XYfSBL543cC8PqguiFoZg68SXlrPBmCbYk70dLi85LuRmG1UkL3piOudOnKmcld+/jl13JsNnsOm/lfhhWJ0x/eSKWzZujnJU9rMC6nUloarbovJV7YlgdNPHFEMSGL1TOqmpq8VNcAmrq6nXeyn0xrA4YMyIYn0Uvhaen46+rvqERa3ck4mFltQs2c18Mqx1DBw3A16si4ePj7TCzWKz4eddelD74xwWbuTeG1YbAAH+YY1cgwL+vw8xms2NTUhpulNxxwWbuj2Fp6OPrA3NsNAYP6K+cx6cfwsXC6zpv1XMwLAVPTxO+jInAyGeGKuf7so+JflCwN2BYCp9ELsHYMc8qZ0f+OIOsEyd13qjnYVhPWRk2H1MmjFPOTuYXIPnQUZ036pkY1v8smj0Tc6a9qpwVXCtCXGqmzhv1XAzrP69PmYwlobOUs6LbpdiQkAK73eAHgJ3AsABMHvcCYsIWKGd3y8qxbmcSrFabzlv1bIYPK2TUCKyOCle+q15ZXYO1OxLR0Njkgs16NkOHFTxkEL6KiYC3t/p6pa+PDzwVN26ofYYNKyiwH8yx0fDv66f5jF8fX3waFa68zkVtM2RY/n5+MMdGY0D/wHaffW7kcISHztZhq97FkGEtmTsLw4cO7vDz82a+pvkxZFIzZFiq/1MVl95D0e1S5fMmkwc+Wh7W5j+b1Johw3ra5es38cO2XdiUtB919Q3KZ/r3C8CHy97VebOey/BhncwvwPr4JFgsVlRUVSMu7aDms5PGPo9Qjc+7U2uGDutw7ilsT8lo9Y56/tVr+P3UOc2/s2zem5qfeqAnDBmW3d6CPZlHkHI4RzlPzjqKkrv3lTMvL0+sjgrXfO+LHjNkWBk5uW2+KtlsdmxMTNV8x33Y4IGICZsvtV6vYMiwKqrbv/hQXlGF+HTt28wzXpmkeWmVDBpWR50tuIIT5/I156sWL8CgoPbfZDUihtWOhMxszVs4PPLRxrDaYbXasDExFc0aN5x55KPGsDrgQfkjJGRma8555OOIYXVQ3oVLOH3xL+WMRz6OGFYn7Nh/CA/KHylnPPJpjWF1gsVixaakNFgsVuWcRz5PMKxOunO/DMlZ2lfAeOTzGMPqgmNnLuD85ULljEc+jzGsLopLzUR5RZVyxiMfhtVljU3N2JyUpnktzOhHPgyrG4pL7yHtt+OacyMf+TCsbsrOO41Lf99Qzox85MOwnGBbygFUVtcoZ0Y98mFYTlDf0IgtyemaX8NtxCMfhuUk127dRkZOrnJmxCMfhuVEmcfzcLXolnJmtCMfhuVkW/emo7q2Tjkz0pEPw3Ky6to6bN2brvldWkY58mFYAq4W3cLhXPX3lBrlyMcj0ryGX1NHTsdXLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSMS//tClrE3peLcAAAAASUVORK5CYII=",
+    "background": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAGm0lEQVR4nO3cWVCVdRjH8R+HTQQR93BJo1Jz1MrRSS21JDUNRWUxMabVpvXcNuNdl100U2qNuQ+KIiCCCIqYoSPkbiippCKiuBDKvp6FLmzG8Pxf1vO858D7+1z6vA7PMN85Oud//scj0rymBUROZnL1AtQ7MSwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEiEl6sXkLThu2+Vfx6Xmom8C5fEfu7bM6Yh8p25ytmjyip8v3knqmpqxX6+O+ArlpNNmzQBy+e/pZzV1tXjx7g9vT4qgGE51fiQ0fhg6SKYTB4Os8amZqyPT0bZwwoXbKY/huUko4KH4fP3lsPLy9NhZrXa8OuefSguveeCzVyDYTnBkIFB+Ob9KPTx9XGY2e0t2L4vA1duFOu/mAsxrG7q598X5tgVCAzwV84TDx7B2YIrOm/legyrG3x9vGGOjcaQgUHKecaxXOScPq/zVu6BYXWRyeSBL1ZGYFTwMOX8+Nk/kX70hM5buQ+G1UUfRyzG+JDRytn5y4XYfSBL543cC8PqguiFoZg68SXlrPBmCbYk70dLi85LuRmG1UkL3piOudOnKmcld+/jl13JsNnsOm/lfhhWJ0x/eSKWzZujnJU9rMC6nUloarbovJV7YlgdNPHFEMSGL1TOqmpq8VNcAmrq6nXeyn0xrA4YMyIYn0Uvhaen46+rvqERa3ck4mFltQs2c18Mqx1DBw3A16si4ePj7TCzWKz4eddelD74xwWbuTeG1YbAAH+YY1cgwL+vw8xms2NTUhpulNxxwWbuj2Fp6OPrA3NsNAYP6K+cx6cfwsXC6zpv1XMwLAVPTxO+jInAyGeGKuf7so+JflCwN2BYCp9ELsHYMc8qZ0f+OIOsEyd13qjnYVhPWRk2H1MmjFPOTuYXIPnQUZ036pkY1v8smj0Tc6a9qpwVXCtCXGqmzhv1XAzrP69PmYwlobOUs6LbpdiQkAK73eAHgJ3AsABMHvcCYsIWKGd3y8qxbmcSrFabzlv1bIYPK2TUCKyOCle+q15ZXYO1OxLR0Njkgs16NkOHFTxkEL6KiYC3t/p6pa+PDzwVN26ofYYNKyiwH8yx0fDv66f5jF8fX3waFa68zkVtM2RY/n5+MMdGY0D/wHaffW7kcISHztZhq97FkGEtmTsLw4cO7vDz82a+pvkxZFIzZFiq/1MVl95D0e1S5fMmkwc+Wh7W5j+b1Johw3ra5es38cO2XdiUtB919Q3KZ/r3C8CHy97VebOey/BhncwvwPr4JFgsVlRUVSMu7aDms5PGPo9Qjc+7U2uGDutw7ilsT8lo9Y56/tVr+P3UOc2/s2zem5qfeqAnDBmW3d6CPZlHkHI4RzlPzjqKkrv3lTMvL0+sjgrXfO+LHjNkWBk5uW2+KtlsdmxMTNV8x33Y4IGICZsvtV6vYMiwKqrbv/hQXlGF+HTt28wzXpmkeWmVDBpWR50tuIIT5/I156sWL8CgoPbfZDUihtWOhMxszVs4PPLRxrDaYbXasDExFc0aN5x55KPGsDrgQfkjJGRma8555OOIYXVQ3oVLOH3xL+WMRz6OGFYn7Nh/CA/KHylnPPJpjWF1gsVixaakNFgsVuWcRz5PMKxOunO/DMlZ2lfAeOTzGMPqgmNnLuD85ULljEc+jzGsLopLzUR5RZVyxiMfhtVljU3N2JyUpnktzOhHPgyrG4pL7yHtt+OacyMf+TCsbsrOO41Lf99Qzox85MOwnGBbygFUVtcoZ0Y98mFYTlDf0IgtyemaX8NtxCMfhuUk127dRkZOrnJmxCMfhuVEmcfzcLXolnJmtCMfhuVkW/emo7q2Tjkz0pEPw3Ky6to6bN2brvldWkY58mFYAq4W3cLhXPX3lBrlyMcj0ryGX1NHTsdXLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSATDIhEMi0QwLBLBsEgEwyIRDItEMCwSwbBIBMMiEQyLRDAsEsGwSMS//tClrE3peLcAAAAASUVORK5CYII=",
+    "isExternal": false,
+    "externalType": "proofread",
+    "workflowId": 3,
+    "hasCrowdsourcing": false,
+    "publicDownloads": true,
+    "createdAt": "2019-09-20T11:34:40+00:00",
+    "updatedAt": "2019-09-20T11:34:40+00:00",
+    "lastActivity": "2019-09-20T11:34:40+00:00",
+    "targetLanguages": [
+      {
+        "id": "es",
+        "name": "Spanish",
+        "editorCode": "es",
+        "twoLettersCode": "es",
+        "threeLettersCode": "spa",
+        "locale": "es-ES",
+        "androidCode": "es-rES",
+        "osxCode": "es.lproj",
+        "osxLocale": "es",
+        "pluralCategoryNames": [
+          "one"
+        ],
+        "pluralRules": "(n != 1)",
+        "pluralExamples": [
+          "0, 2-999; 1.2, 2.07..."
+        ],
+        "textDirection": "ltr",
+        "dialectOf": "string"
+      }
+    ]
+  },
+};
+

--- a/Zapier Extension/resources/string.js
+++ b/Zapier Extension/resources/string.js
@@ -1,0 +1,117 @@
+const { projectInputField, filesInputField, labelsInputField, getCrowdinConnection } = require('./../_shared');
+
+const performSearch = async (z, bundle) => {
+  const { sourceStringsApi } = await getCrowdinConnection(z, bundle);
+  const strings = (await sourceStringsApi.withFetchAll().listProjectStrings(bundle.inputData.project_id)).data.map((obj) => obj.data)
+
+  if (bundle.inputData.text) {
+    return strings.filter(string => string.text == bundle.inputData.text)
+  }
+
+  if (bundle.inputData.identifier) {
+    return strings.filter(string => string.identifier == bundle.inputData.identifier)
+  }
+
+  if (bundle.inputData.context) {
+    return strings.filter(string => string.context == bundle.inputData.context)
+  }
+
+  return []
+};
+
+const performCreate = async (z, bundle) => {
+  const { sourceStringsApi } = await getCrowdinConnection(z, bundle);
+
+  let request = {
+    text: bundle.inputData.text,
+    identifier: bundle.inputData.identifier,
+    fileId: bundle.inputData.file_id
+  }
+
+  bundle.inputData.label_id && (request.labelIds = bundle.inputData.label_id)
+  bundle.inputData.context && (request.context = bundle.inputData.context)
+  bundle.inputData.maxLength && (request.maxLength = bundle.inputData.maxLength)
+
+  if (bundle.inputData.hidden !== undefined) {
+    request.isHidden = (bundle.inputData.hidden ? true : false)
+  }
+
+  return (await sourceStringsApi.addString(bundle.inputData.project_id, request)).data
+};
+
+module.exports = {
+  key: 'string',
+  noun: 'String',
+
+  search: {
+    display: {
+      label: 'Find String',
+      description: 'Finds a string by text.'
+    },
+    operation: {
+      inputFields: [
+        projectInputField,
+        { key: 'text', required: false },
+        { key: 'identifier', required: false },
+        { key: 'context', required: false }
+      ],
+      perform: performSearch
+    },
+  },
+
+  create: {
+    display: {
+      label: 'Create String',
+      description: 'Creates a new string.'
+    },
+    operation: {
+      inputFields: [
+        projectInputField,
+        filesInputField,
+        { key: 'text', required: true },
+        { key: 'identifier', required: true },
+        { key: 'context' }, {
+          required: false,
+          label: "Is Hidden",
+          helpText: "Is the string visible to translators.",
+          key: "hidden",
+          type: "boolean",
+        }, {
+          ...labelsInputField,
+          list: true,
+          required: false
+        }, {
+          type: 'integer',
+          key: 'maxLength',
+          required: false,
+          label: 'Max. Length'
+        }
+      ],
+      perform: performCreate
+    },
+  },
+
+  sample: {
+    "id": 2814,
+    "projectId": 2,
+    "fileId": 48,
+    "branchId": 12,
+    "directoryId": 13,
+    "identifier": "name",
+    "text": "Not all videos are shown to users. See more",
+    "type": "text",
+    "context": "shown on main page",
+    "maxLength": 35,
+    "isHidden": false,
+    "isDuplicate": true,
+    "masterStringId": 1,
+    "revision": 1,
+    "hasPlurals": false,
+    "isIcu": false,
+    "labelIds": [
+      3
+    ],
+    "createdAt": "2019-09-20T12:43:57+00:00",
+    "updatedAt": "2019-09-20T13:24:01+00:00"
+  }
+};

--- a/Zapier Extension/resources/task.js
+++ b/Zapier Extension/resources/task.js
@@ -1,0 +1,163 @@
+const { projectInputField, projectWorkflowStepField, languageInputField, filesInputField, labelsInputField, projectMembersField, getCrowdinConnection } = require('./../_shared');
+
+const performSearch = async (z, bundle) => {
+  const { tasksApi } = await getCrowdinConnection(z, bundle);
+
+  if (bundle.inputData.id) {
+    return (await tasksApi.withFetchAll().getTask(bundle.inputData.project_id, bundle.inputData.id)).data
+  } else if (bundle.inputData.title) {
+    return (await tasksApi.withFetchAll().listTasks(bundle.inputData.project_id)).data.map((obj) => obj.data).filter(task => task.title == bundle.inputData.title)
+  } else {
+    return []
+  }
+};
+
+const performCreate = async (z, bundle) => {
+  const { tasksApi } = await getCrowdinConnection(z, bundle);
+
+  let request = {
+    status: 'todo',
+    title: bundle.inputData.title,
+    languageId: bundle.inputData.language_id,
+    fileIds: bundle.inputData.file_id,
+  }
+
+  if (bundle.authData.domain) {
+    if (!bundle.inputData.workflow_step_id) {
+      throw new Error("Workflow step is required for Crowdin Enterprise")
+    }
+
+    request.workflowStepId = bundle.inputData.workflow_step_id
+  } else {
+    if (bundle.inputData.task_type === undefined) {
+      throw new Error("Task type is required for crowdin.com")
+    }
+
+    request.type = bundle.inputData.task_type
+  }
+
+  bundle.inputData.description && (request.description = bundle.inputData.description)
+  // bundle.inputData.deadline && (request.deadline = bundle.inputData.deadline)
+  bundle.inputData.skipAssignedStrings && (request.skipAssignedStrings = bundle.inputData.skipAssignedStrings)
+  bundle.inputData.label_id && (request.labelIds = bundle.inputData.label_id)
+  bundle.inputData.project_member && (request.assignees = bundle.inputData.project_member.map(id => { return { id } }))
+
+  try {
+    return (await tasksApi.addTask(bundle.inputData.project_id, request)).data
+  } catch (e) {
+    if (e.error && e.error.message) {
+      throw new Error(e.error.message)
+    }
+
+    if (e.errors) {
+      throw new Error(JSON.stringify(e.errors[0].error))
+    }
+  }
+};
+
+module.exports = {
+  key: 'task',
+  noun: 'Task',
+
+  search: {
+    display: {
+      label: 'Find Task',
+      description: 'Finds a task give.'
+    },
+    operation: {
+      inputFields: [
+        projectInputField,
+        { key: 'title', required: false },
+        { key: 'id', required: false }
+      ],
+      perform: performSearch
+    },
+  },
+
+  create: {
+    display: {
+      label: 'Create Task',
+      description: 'Creates a new task.'
+    },
+    operation: {
+      inputFields: [
+        projectInputField,
+        { ...projectWorkflowStepField, label: 'Workflow Step (used only in Crowdin Enterprise)', required: false }, {
+          key: 'task_type',
+          type: 'integer',
+          label: 'Task Type (used only in crowdin.com)',
+          required: false,
+          choices: [
+            { value: '0', label: 'Translate', sample: '0' },
+            { value: '1', label: 'Proofread', sample: '1' }
+          ],
+          altersDynamicFields: false,
+        },
+        { ...projectMembersField, label: 'Assignees', list: true, required: false },
+        { key: 'title', required: true },
+        languageInputField,
+        { ...filesInputField, list: true },
+        { key: 'description' },
+        { ...labelsInputField, list: true, required: false },
+        // { key: 'deadline', type: 'datetime' },
+        { key: 'skipAssignedStrings', type: 'boolean' }
+      ],
+      perform: performCreate
+    },
+  },
+
+  sample: {
+    "data": {
+      "id": 2,
+      "projectId": 2,
+      "creatorId": 6,
+      "type": 1,
+      "vendor": "gengo",
+      "status": "todo",
+      "title": "French",
+      "assignees": [
+        {
+          "id": 1,
+          "username": "john_smith",
+          "fullName": "John Smith",
+          "avatarUrl": "",
+          "wordsCount": 5,
+          "wordsLeft": 3
+        }
+      ],
+      "assignedTeams": [
+        {
+          "id": 1,
+          "wordsCount": 5
+        }
+      ],
+      "fileIds": [
+        1
+      ],
+      "progress": {
+        "total": 24,
+        "done": 15,
+        "percent": 62
+      },
+      "translateProgress": {
+        "total": 24,
+        "done": 15,
+        "percent": 62
+      },
+      "sourceLanguageId": "en",
+      "targetLanguageId": "fr",
+      "description": "Proofread all French strings",
+      "hash": "dac37aff364d83899128e68afe0de4994",
+      "translationUrl": "/proofread/9092638ac9f2a2d1b5571d08edc53763/all/en-fr/10?task=dac37aff364d83899128e68afe0de4994",
+      "wordsCount": 24,
+      "filesCount": 2,
+      "commentsCount": 0,
+      "deadline": "2019-09-27T07:00:14+00:00",
+      "timeRange": "string",
+      "workflowStepId": 10,
+      "buyUrl": "https://www.paypal.com/cgi-bin/webscr?cmd=...",
+      "createdAt": "2019-09-23T09:04:29+00:00",
+      "updatedAt": "2019-09-23T09:04:29+00:00"
+    }
+  }
+};

--- a/Zapier Extension/searches/find_file.js
+++ b/Zapier Extension/searches/find_file.js
@@ -1,0 +1,48 @@
+const { projectInputField, filesInputField, getCrowdinConnection } = require('../_shared');
+
+module.exports = {
+  operation: {
+    inputFields: [projectInputField, filesInputField, {
+      required: false,
+      label: "Name",
+      helpText: "File Name.",
+      key: "name",
+      type: "string",
+    }],
+    perform: async (z, bundle) => {
+      const { sourceFilesApi } = await getCrowdinConnection(z, bundle);
+
+      const data = (await sourceFilesApi.withFetchAll().listProjectFiles(bundle.inputData.project_id)).data.map((obj) => obj.data)
+
+      var result = null
+
+      if (bundle.inputData.file_id) {
+        result = data.find((file) => file.id == bundle.inputData.file_id)
+      } else if (bundle.inputData.name) {
+        result = data.find((file) => file.name == bundle.inputData.name)
+      } else {
+        result = data[0]
+      }
+
+      return [result]
+    },
+    sample: {
+      "id": 44,
+      "projectId": 2,
+      "branchId": 34,
+      "directoryId": 4,
+      "name": "umbrella_app.xliff",
+      "title": "source_app_info",
+      "type": "xliff",
+      "path": "/directory1/directory2/filename.extension",
+      "status": "active"
+    }
+  },
+  key: 'find_file',
+  noun: 'File',
+  display: {
+    label: 'Find File',
+    description: 'Finds file by id or name.',
+    hidden: false,
+  },
+};

--- a/Zapier Extension/searches/find_language.js
+++ b/Zapier Extension/searches/find_language.js
@@ -1,0 +1,71 @@
+const { getCrowdinConnection } = require('../_shared');
+
+module.exports = {
+  operation: {
+    inputFields: [{
+      required: false,
+      label: "Code",
+      helpText: "Crowdin Language Code (sometimes called language ID, i.e. 'fr', 'uk').",
+      key: "code",
+      type: "string",
+    }, {
+      required: false,
+      label: "Name",
+      helpText: "Crowdin Language Name.",
+      key: "name",
+      type: "string",
+    }, {
+      required: false,
+      label: "Locale",
+      helpText: "Crowdin Language Locale.",
+      key: "locale",
+      type: "string",
+    }],
+    perform: async (z, bundle) => {
+      const { languagesApi } = await getCrowdinConnection(z, bundle);
+
+      const data = (await languagesApi.withFetchAll().listSupportedLanguages()).data.map((obj) => obj.data)
+
+      var result = null
+
+      if (bundle.inputData.code) {
+        result = data.find((lng) => lng.id == bundle.inputData.code)
+      } else if (bundle.inputData.name) {
+        result = data.find((lng) => lng.name == bundle.inputData.name)
+      } else if (bundle.inputData.locale) {
+        result = data.find((lng) => lng.locale == bundle.inputData.locale)
+      } else {
+        result = data[0]
+      }
+
+      return [result]
+    },
+    sample: {
+      "id": "es",
+      "name": "Spanish",
+      "editorCode": "es",
+      "twoLettersCode": "es",
+      "threeLettersCode": "spa",
+      "locale": "es-ES",
+      "androidCode": "es-rES",
+      "osxCode": "es.lproj",
+      "osxLocale": "es",
+      "pluralCategoryNames": [],
+      "pluralRules": "(n != 1)",
+      "pluralExamples": [],
+      "textDirection": "ltr",
+      "dialectOf": "string"
+    },
+    outputFields: [
+      { key: 'id', label: 'Crowdin Language Code' },
+      { key: 'name', label: 'Language Name' }
+    ],
+  },
+  key: 'find_language',
+  noun: 'Languages',
+  display: {
+    label: 'Find Language',
+    description: 'Finds language by Crowdin code, locale or name.',
+    hidden: false,
+  },
+};

--- a/Zapier Extension/triggers/_shared_file.js
+++ b/Zapier Extension/triggers/_shared_file.js
@@ -1,0 +1,29 @@
+const { getCrowdinConnection } = require('./../_shared');
+
+const performSearchFile = async (z, bundle, event) => {
+    const { projectsGroupsApi, sourceFilesApi } = await getCrowdinConnection(z, bundle);
+
+    const project = (await projectsGroupsApi.getProject(bundle.inputData.project_id)).data
+    const files = (await sourceFilesApi.listProjectFiles(bundle.inputData.project_id, {
+        limit: 1
+    }))
+
+    if (files.data && files.data.length) {
+        const file = files.data[0].data;
+
+        return [{
+            event: event,
+            project: project.identifier,
+            project_id: project.id,
+            language: project.targetLanguageIds[0],
+            file_id: file.id,
+            file: file.name
+        }]
+    } else {
+        return []
+    }
+}
+
+module.exports = {
+    performSearchFile
+};

--- a/Zapier Extension/triggers/_shared_file_revision.js
+++ b/Zapier Extension/triggers/_shared_file_revision.js
@@ -1,0 +1,33 @@
+const { getCrowdinConnection } = require('./../_shared');
+
+const performSearchFile = async (z, bundle, event) => {
+    const { projectsGroupsApi, sourceFilesApi, usersApi } = await getCrowdinConnection(z, bundle);
+
+    const project = (await projectsGroupsApi.getProject(bundle.inputData.project_id)).data
+    const files = (await sourceFilesApi.listProjectFiles(bundle.inputData.project_id, {
+        limit: 1
+    }))
+
+    if (files.data && files.data.length) {
+        const file = files.data[0].data;
+        const user = (await usersApi.getAuthenticatedUser()).data
+
+        return [{
+            event: event,
+            project: project.identifier,
+            project_id: project.id,
+            language: project.targetLanguageIds[0],
+            file_id: file.id,
+            file: file.name,
+            user_id: user.id,
+            user: user.username,
+            revision: file.revisionId
+        }]
+    } else {
+        return []
+    }
+}
+
+module.exports = {
+    performSearchFile
+};

--- a/Zapier Extension/triggers/_shared_project.js
+++ b/Zapier Extension/triggers/_shared_project.js
@@ -1,0 +1,18 @@
+const { getCrowdinConnection } = require('./../_shared');
+
+const performSearchProject = async (z, bundle, event) => {
+    const { projectsGroupsApi } = await getCrowdinConnection(z, bundle);
+
+    const project = (await projectsGroupsApi.getProject(bundle.inputData.project_id)).data
+
+    return [{
+        event: event,
+        project: project.identifier,
+        project_id: project.id,
+        language: project.targetLanguageIds[0]
+    }]
+}
+
+module.exports = {
+    performSearchProject
+};

--- a/Zapier Extension/triggers/comment_created.js
+++ b/Zapier Extension/triggers/comment_created.js
@@ -1,0 +1,111 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+
+const sampleIssue = {
+  "event": "stringComment.created",
+  "comment": {
+    "id": "12",
+    "text": "@BeMyEyes  Please provide more details on where the text will be used",
+    "type": "issue",
+    "issueType": "source_mistake",
+    "issueStatus": "unresolved",
+    "resolvedAt": "2019-09-20T11:05:24+00:00",
+    "createdAt": "2019-09-20T11:05:24+00:00",
+    "string": {
+      "id": "2814",
+      "identifier": "name",
+      "text": "Not all videos are shown to users. See more",
+      "type": "text",
+      "context": "shown on main page",
+      "maxLength": "35",
+      "isHidden": false,
+      "isDuplicate": true,
+      "masterStringId": "1",
+      "revision": "1",
+      "hasPlurals": false,
+      "labelIds": [
+        3,
+        8
+      ],
+      "url": "https://example.crowdin.com/translate/file-format-samples/1/en-uk/78#1",
+      "createdAt": "2022-04-20T12:43:57+00:00",
+      "updatedAt": "2022-04-20T13:24:01+00:00",
+      "file": {
+        "id": "44",
+        "name": "umbrella_app.xliff",
+        "title": "source_app_info",
+        "type": "xliff",
+        "path": "/directory1/directory2/filename.extension",
+        "status": "active",
+        "revision": "1",
+        "branchId": "34",
+        "directoryId": "4"
+      },
+      "project": {
+        "id": "777",
+        "userId": "1",
+        "sourceLanguageId": "en",
+        "targetLanguageIds": [
+          "uk",
+          "pl"
+        ],
+        "identifier": "umbrella",
+        "name": "Project Name",
+        "createdAt": "2022-04-20T11:05:24+00:00",
+        "updatedAt": "2022-04-21T11:07:29+00:00",
+        "lastActivity": "2022-04-21T11:07:29+00:00",
+        "description": "Project Description",
+        "url": "https://crowdin.com/project/umbrella",
+        "cname": null,
+        "languageAccessPolicy": "moderate",
+        "visibility": "private",
+        "publicDownloads": true
+      }
+    },
+    "targetLanguage": {
+      "id": "es",
+      "name": "Spanish",
+      "editorCode": "es",
+      "twoLettersCode": "es",
+      "threeLettersCode": "spa",
+      "locale": "es-ES",
+      "androidCode": "es-rES",
+      "osxCode": "es.lproj",
+      "osxLocale": "es",
+      "textDirection": "ltr",
+      "dialectOf": null
+    },
+    "user": {
+      "id": "1",
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    },
+    "commentResolver": {
+      "id": "1",
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    }
+  }
+};
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'stringComment.created') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => {
+      return [sampleIssue];
+    },
+    sample: sampleIssue
+  },
+  key: 'comment_created',
+  noun: 'Comment',
+  display: {
+    label: 'Comment/Issue Added',
+    description: 'Triggers when a user creates a comment or an issue.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/comment_deleted.js
+++ b/Zapier Extension/triggers/comment_deleted.js
@@ -1,0 +1,111 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+
+const sampleIssue = {
+  "event": "stringComment.deleted",
+  "comment": {
+    "id": "12",
+    "text": "@BeMyEyes  Please provide more details on where the text will be used",
+    "type": "issue",
+    "issueType": "source_mistake",
+    "issueStatus": "unresolved",
+    "resolvedAt": "2019-09-20T11:05:24+00:00",
+    "createdAt": "2019-09-20T11:05:24+00:00",
+    "string": {
+      "id": "2814",
+      "identifier": "name",
+      "text": "Not all videos are shown to users. See more",
+      "type": "text",
+      "context": "shown on main page",
+      "maxLength": "35",
+      "isHidden": false,
+      "isDuplicate": true,
+      "masterStringId": "1",
+      "revision": "1",
+      "hasPlurals": false,
+      "labelIds": [
+        3,
+        8
+      ],
+      "url": "https://example.crowdin.com/translate/file-format-samples/1/en-uk/78#1",
+      "createdAt": "2022-04-20T12:43:57+00:00",
+      "updatedAt": "2022-04-20T13:24:01+00:00",
+      "file": {
+        "id": "44",
+        "name": "umbrella_app.xliff",
+        "title": "source_app_info",
+        "type": "xliff",
+        "path": "/directory1/directory2/filename.extension",
+        "status": "active",
+        "revision": "1",
+        "branchId": "34",
+        "directoryId": "4"
+      },
+      "project": {
+        "id": "777",
+        "userId": "1",
+        "sourceLanguageId": "en",
+        "targetLanguageIds": [
+          "uk",
+          "pl"
+        ],
+        "identifier": "umbrella",
+        "name": "Project Name",
+        "createdAt": "2022-04-20T11:05:24+00:00",
+        "updatedAt": "2022-04-21T11:07:29+00:00",
+        "lastActivity": "2022-04-21T11:07:29+00:00",
+        "description": "Project Description",
+        "url": "https://crowdin.com/project/umbrella",
+        "cname": null,
+        "languageAccessPolicy": "moderate",
+        "visibility": "private",
+        "publicDownloads": true
+      }
+    },
+    "targetLanguage": {
+      "id": "es",
+      "name": "Spanish",
+      "editorCode": "es",
+      "twoLettersCode": "es",
+      "threeLettersCode": "spa",
+      "locale": "es-ES",
+      "androidCode": "es-rES",
+      "osxCode": "es.lproj",
+      "osxLocale": "es",
+      "textDirection": "ltr",
+      "dialectOf": null
+    },
+    "user": {
+      "id": "1",
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    },
+    "commentResolver": {
+      "id": "1",
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    }
+  }
+};
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'stringComment.deleted') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => {
+      return [sampleIssue];
+    },
+    sample: sampleIssue
+  },
+  key: 'comment_deleted',
+  noun: 'Comment',
+  display: {
+    label: 'Comment/Issue Deleted',
+    description: 'Triggers when a user deletes a comment or an issue.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/comment_restored.js
+++ b/Zapier Extension/triggers/comment_restored.js
@@ -1,0 +1,111 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+
+const sampleIssue = {
+  "event": "stringComment.restored",
+  "comment": {
+    "id": "12",
+    "text": "@BeMyEyes  Please provide more details on where the text will be used",
+    "type": "issue",
+    "issueType": "source_mistake",
+    "issueStatus": "unresolved",
+    "resolvedAt": "2019-09-20T11:05:24+00:00",
+    "createdAt": "2019-09-20T11:05:24+00:00",
+    "string": {
+      "id": "2814",
+      "identifier": "name",
+      "text": "Not all videos are shown to users. See more",
+      "type": "text",
+      "context": "shown on main page",
+      "maxLength": "35",
+      "isHidden": false,
+      "isDuplicate": true,
+      "masterStringId": "1",
+      "revision": "1",
+      "hasPlurals": false,
+      "labelIds": [
+        3,
+        8
+      ],
+      "url": "https://example.crowdin.com/translate/file-format-samples/1/en-uk/78#1",
+      "createdAt": "2022-04-20T12:43:57+00:00",
+      "updatedAt": "2022-04-20T13:24:01+00:00",
+      "file": {
+        "id": "44",
+        "name": "umbrella_app.xliff",
+        "title": "source_app_info",
+        "type": "xliff",
+        "path": "/directory1/directory2/filename.extension",
+        "status": "active",
+        "revision": "1",
+        "branchId": "34",
+        "directoryId": "4"
+      },
+      "project": {
+        "id": "777",
+        "userId": "1",
+        "sourceLanguageId": "en",
+        "targetLanguageIds": [
+          "uk",
+          "pl"
+        ],
+        "identifier": "umbrella",
+        "name": "Project Name",
+        "createdAt": "2022-04-20T11:05:24+00:00",
+        "updatedAt": "2022-04-21T11:07:29+00:00",
+        "lastActivity": "2022-04-21T11:07:29+00:00",
+        "description": "Project Description",
+        "url": "https://crowdin.com/project/umbrella",
+        "cname": null,
+        "languageAccessPolicy": "moderate",
+        "visibility": "private",
+        "publicDownloads": true
+      }
+    },
+    "targetLanguage": {
+      "id": "es",
+      "name": "Spanish",
+      "editorCode": "es",
+      "twoLettersCode": "es",
+      "threeLettersCode": "spa",
+      "locale": "es-ES",
+      "androidCode": "es-rES",
+      "osxCode": "es.lproj",
+      "osxLocale": "es",
+      "textDirection": "ltr",
+      "dialectOf": null
+    },
+    "user": {
+      "id": "1",
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    },
+    "commentResolver": {
+      "id": "1",
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    }
+  }
+};
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'stringComment.restored') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => {
+      return [sampleIssue];
+    },
+    sample: sampleIssue
+  },
+  key: 'comment_restored',
+  noun: 'Comment',
+  display: {
+    label: 'Comment/Issue Restored',
+    description: 'Triggers when a user restores a deleted comment or an issue.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/comment_updated.js
+++ b/Zapier Extension/triggers/comment_updated.js
@@ -1,0 +1,111 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+
+const sampleIssue = {
+  "event": "stringComment.updated",
+  "comment": {
+    "id": "12",
+    "text": "@BeMyEyes  Please provide more details on where the text will be used",
+    "type": "issue",
+    "issueType": "source_mistake",
+    "issueStatus": "unresolved",
+    "resolvedAt": "2019-09-20T11:05:24+00:00",
+    "createdAt": "2019-09-20T11:05:24+00:00",
+    "string": {
+      "id": "2814",
+      "identifier": "name",
+      "text": "Not all videos are shown to users. See more",
+      "type": "text",
+      "context": "shown on main page",
+      "maxLength": "35",
+      "isHidden": false,
+      "isDuplicate": true,
+      "masterStringId": "1",
+      "revision": "1",
+      "hasPlurals": false,
+      "labelIds": [
+        3,
+        8
+      ],
+      "url": "https://example.crowdin.com/translate/file-format-samples/1/en-uk/78#1",
+      "createdAt": "2022-04-20T12:43:57+00:00",
+      "updatedAt": "2022-04-20T13:24:01+00:00",
+      "file": {
+        "id": "44",
+        "name": "umbrella_app.xliff",
+        "title": "source_app_info",
+        "type": "xliff",
+        "path": "/directory1/directory2/filename.extension",
+        "status": "active",
+        "revision": "1",
+        "branchId": "34",
+        "directoryId": "4"
+      },
+      "project": {
+        "id": "777",
+        "userId": "1",
+        "sourceLanguageId": "en",
+        "targetLanguageIds": [
+          "uk",
+          "pl"
+        ],
+        "identifier": "umbrella",
+        "name": "Project Name",
+        "createdAt": "2022-04-20T11:05:24+00:00",
+        "updatedAt": "2022-04-21T11:07:29+00:00",
+        "lastActivity": "2022-04-21T11:07:29+00:00",
+        "description": "Project Description",
+        "url": "https://crowdin.com/project/umbrella",
+        "cname": null,
+        "languageAccessPolicy": "moderate",
+        "visibility": "private",
+        "publicDownloads": true
+      }
+    },
+    "targetLanguage": {
+      "id": "es",
+      "name": "Spanish",
+      "editorCode": "es",
+      "twoLettersCode": "es",
+      "threeLettersCode": "spa",
+      "locale": "es-ES",
+      "androidCode": "es-rES",
+      "osxCode": "es.lproj",
+      "osxLocale": "es",
+      "textDirection": "ltr",
+      "dialectOf": null
+    },
+    "user": {
+      "id": "1",
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    },
+    "commentResolver": {
+      "id": "1",
+      "username": "john_smith",
+      "fullName": "John Smith",
+      "avatarUrl": ""
+    }
+  }
+};
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'stringComment.updated') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => {
+      return [sampleIssue];
+    },
+    sample: sampleIssue
+  },
+  key: 'comment_updated',
+  noun: 'Comment',
+  display: {
+    label: 'Comment/Issue Updated',
+    description: 'Triggers when a user updates a comment or an issue.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/file_added.js
+++ b/Zapier Extension/triggers/file_added.js
@@ -1,0 +1,35 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+const { performSearchFile } = require('./_shared_file_revision')
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'file.added') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => {
+      let file = await performSearchFile(z, bundle, 'file.added')
+      delete file[0].language;
+
+      return file;
+    },
+    sample: {
+      "event": "file.added",
+      "project": "mobile",
+      "project_id": "220",
+      "file_id": "14",
+      "file": "Localizable.strings",
+      "user_id": "4",
+      "user": "peter",
+      "revision": "1"
+    }
+  },
+  key: 'file_added',
+  noun: 'File',
+  display: {
+    label: 'File Added',
+    description: 'Triggers when a new file has been added to the project.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/file_approved.js
+++ b/Zapier Extension/triggers/file_approved.js
@@ -1,0 +1,28 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+const { performSearchFile } = require('./_shared_file')
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'file.approved') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => { return await performSearchFile(z, bundle, 'file.approved') },
+    sample: {
+      "event": "file.approved",
+      "project": "mobile",
+      "project_id": 220,
+      "language": "uk",
+      "file_id": 254,
+      "file": "strings.xml"
+    }
+  },
+  key: 'file_approved',
+  noun: 'File',
+  display: {
+    label: 'File Approved',
+    description: 'Triggers when a file is fully translated and approved.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/file_deleted.js
+++ b/Zapier Extension/triggers/file_deleted.js
@@ -1,0 +1,35 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+const { performSearchFile } = require('./_shared_file_revision')
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'file.deleted') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => {
+      const file = await performSearchFile(z, bundle, 'file.deleted');
+      delete file[0].revision;
+      delete file[0].language;
+
+      return file;
+    },
+    sample: {
+      "event": "file.deleted",
+      "project": "web",
+      "project_id": 43,
+      "file_id": 1,
+      "file": "about.html",
+      "user_id": 8,
+      "user": "peter"
+    }
+  },
+  key: 'file_deleted',
+  noun: 'File',
+  display: {
+    label: 'File Deleted',
+    description: 'Triggers when a file has been deleted from the project.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/file_reverted.js
+++ b/Zapier Extension/triggers/file_reverted.js
@@ -1,0 +1,35 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+const { performSearchFile } = require('./_shared_file_revision')
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'file.reverted') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => {
+      const file = await performSearchFile(z, bundle, 'file.reverted')
+      delete file[0].language;
+
+      return file;
+    },
+    sample: {
+      "event": "file.reverted",
+      "project": "web",
+      "project_id": 220,
+      "file_id": 1,
+      "file": "index.html",
+      "user_id": 4,
+      "user": "peter",
+      "revision": 1
+    }
+  },
+  key: 'file_reverted',
+  noun: 'File',
+  display: {
+    label: 'File Reverted',
+    description: 'Triggers when a file update has been reverted.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/file_translated.js
+++ b/Zapier Extension/triggers/file_translated.js
@@ -1,0 +1,28 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+const { performSearchFile } = require('./_shared_file')
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'file.translated') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => { return await performSearchFile(z, bundle, 'file.translated') },
+    sample: {
+      "event": "file.translated",
+      "project": "aecf449472b669351cce576fc23aabd6",
+      "project_id": "220",
+      "language": "uk",
+      "file_id": "1",
+      "file": "example.txt"
+    }
+  },
+  key: 'file_translated',
+  noun: 'File',
+  display: {
+    label: 'File Translated',
+    description: 'Triggers when a file is fully translated.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/file_updated.js
+++ b/Zapier Extension/triggers/file_updated.js
@@ -1,0 +1,35 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+const { performSearchFile } = require('./_shared_file_revision')
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'file.updated') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => {
+      const file = await performSearchFile(z, bundle, 'file.updated')
+      delete file[0].language;
+
+      return file;
+    },
+    sample: {
+      "event": "file.updated",
+      "project": "web",
+      "project_id": "220",
+      "file_id": "4",
+      "file": "index.html",
+      "user_id": "1",
+      "user": "peter",
+      "revision": "1"
+    }
+  },
+  key: 'file_updated',
+  noun: 'File',
+  display: {
+    label: 'File Updated',
+    description: 'Triggers when a file has been updated.',
+    hidden: false,
+  }
+}

--- a/Zapier Extension/triggers/project_approved.js
+++ b/Zapier Extension/triggers/project_approved.js
@@ -1,0 +1,26 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+const { performSearchProject } = require('./_shared_project')
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'project.approved') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => { return await performSearchProject(z, bundle, 'project.approved') },
+    sample: {
+      "event": "project.approved",
+      "project": "aecf449472b669351cce576fc23aabd6",
+      "project_id": "220",
+      "language": "uk"
+    }
+  },
+  key: 'project_approved',
+  noun: 'Project',
+  display: {
+    label: 'Project Language Approved',
+    description: 'Triggers when one of a project languages is fully translated and approved.',
+    hidden: false,
+  }
+};

--- a/Zapier Extension/triggers/project_translated.js
+++ b/Zapier Extension/triggers/project_translated.js
@@ -1,0 +1,26 @@
+const { handleWebhook, subscribeToCrowdin, performUnsubscribe, projectInputField } = require('../_shared')
+const { performSearchProject } = require('./_shared_project')
+
+module.exports = {
+  operation: {
+    perform: handleWebhook,
+    inputFields: [projectInputField],
+    type: 'hook',
+    performSubscribe: async (z, bundle) => { return await subscribeToCrowdin(z, bundle, 'project.translated') },
+    performUnsubscribe: async (z, bundle) => { return await performUnsubscribe(z, bundle) },
+    performList: async (z, bundle) => { return await performSearchProject(z, bundle, 'project.translated') },
+    sample: {
+      "event": "project.translated",
+      "project": "aecf449472b669351cce576fc23aabd6",
+      "project_id": "220",
+      "language": "uk"
+    }
+  },
+  key: 'project_translated',
+  noun: 'Project',
+  display: {
+    label: 'Project Language Translated',
+    description: 'Triggers when one of a project languages is fully translated.',
+    hidden: false,
+  }
+};


### PR DESCRIPTION
# Description

I would like a Zapier extension that simplifies the creation and management of workflows. This extension should allow users to easily connect different apps and automate tasks without requiring extensive technical knowledge. The extension should offer a user-friendly interface with drag-and-drop functionality to create workflows and a library of pre-built templates for common use cases.


Fixes:  #1770 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/142833275/1f32e694-5984-4c10-9104-b6ece6a5f52d)

