### PR TITLE
Fix Broken Navigation Links in Caesar Cipher

### DIFF
--- a/Ceaser Cipher/decrypt.html
+++ b/Ceaser Cipher/decrypt.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
     <title>Caesar&Cipher</title>
 </head>
 
@@ -22,8 +22,8 @@
 
     <div class="buttons">
         <button id="decryption">Decrypt</button>
-        <a href="/encrypt.html"><button>Encrypt message</button></a>
-        <a href="/index.html"><button>Home</button></a>
+        <a href="./encrypt.html"><button>Encrypt message</button></a>
+        <a href="./index.html"><button>Home</button></a>
     </div>
     <div class="decrypt-msg">
         Decrypted message will come here

--- a/Ceaser Cipher/encrypt.html
+++ b/Ceaser Cipher/encrypt.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
     <title>Caesar&Cipher</title>
 </head>
 
@@ -22,8 +22,8 @@
 
     <div class="buttons">
         <button id="encrypt">Encrypt</button>
-        <a href="/decrypt.html"><button>Decrypt message</button></a>
-        <a href="/index.html"><button>Home</button></a>
+        <a href="./decrypt.html"><button>Decrypt message</button></a>
+        <a href="./index.html"><button>Home</button></a>
     </div>
     <div class="encrypt-msg">
         encrypt message will come here

--- a/Ceaser Cipher/index.html
+++ b/Ceaser Cipher/index.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Caesar&Cipher</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" />
 </head>
 <body> 
     <h1>Caesar&Cipher</h1>
     <div class="options">
-        <a href="/encrypt.html"><button class="encrypt">Encrypt</button></a>
-        <a href="/decrypt.html"><button class="decrypt">Decrypt</button></a>
+        <a href="./encrypt.html"><button class="encrypt">Encrypt</button></a>
+        <a href="./decrypt.html"><button class="decrypt">Decrypt</button></a>
     </div>
     <div class="footer">
     </div>


### PR DESCRIPTION
Fixed issue: #1915 

- Corrected the href attributes in the navigation links of the Caesar Cipher tool.
- Ensured all navigation paths are accurate, enabling proper internal navigation.
- Updated paths to reflect the correct locations of the tool's various sections.
- Verified link functionality to prevent broken or incorrect navigation, enhancing user experience.
- Conducted thorough testing to ensure all links direct users to the intended destinations.

Fixes:  #1915 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have made this from my own 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/159511364/7e5abb81-0d55-4021-985d-61b07b474408


