### PR TITLE
Draw scores are now displayed along with user and cpu score in rock paper scissors game.

### DIFF
--- a/Rock Paper Scissors/index.html
+++ b/Rock Paper Scissors/index.html
@@ -22,6 +22,7 @@
       <div class="result">Let's Play!!</div>
       <div class="scores">
         <span class="user_score">User: 0</span>
+        <span class="tie_score">Draw: 0</span>
         <span class="cpu_score">CPU: 0</span>
       </div>
     </div>

--- a/Rock Paper Scissors/scripts/script.js
+++ b/Rock Paper Scissors/scripts/script.js
@@ -4,12 +4,14 @@ const gameContainer = document.querySelector(".container"),
   result = document.querySelector(".result"),
   userScoreDisplay = document.querySelector(".user_score"),
   cpuScoreDisplay = document.querySelector(".cpu_score"),
+  tieScoreDisplay = document.querySelector(".tie_score");
   resetButton = document.querySelector(".reset"),
   winnerModal = document.getElementById("winnerModal"),
   winnerMessage = document.getElementById("winnerMessage"),
   playAgainButton = document.getElementById("playAgainButton");
 
 let userScore = 0,
+  tieScore=0,
   cpuScore = 0;
 
 const optionImages = document.querySelectorAll(".option_image");
@@ -29,8 +31,10 @@ function showWinner(winner) {
 
 function resetGame() {
   userScore = 0;
+  tieScore = 0;
   cpuScore = 0;
   userScoreDisplay.textContent = `User: ${userScore}`;
+  tieScoreDisplay.textContent = `Draw: ${tieScore}`;
   cpuScoreDisplay.textContent = `CPU: ${cpuScore}`;
   result.textContent = "Let's Play!!";
   optionImages.forEach(image => image.classList.remove("active"));
@@ -87,11 +91,13 @@ optionImages.forEach((image, index) => {
         userScore++;
       } else if (outComeValue === "Cpu") {
         cpuScore++;
+      } else{
+        tieScore++;
       }
 
       userScoreDisplay.textContent = `User: ${userScore}`;
       cpuScoreDisplay.textContent = `CPU: ${cpuScore}`;
-
+      tieScoreDisplay.textContent = `Draw: ${tieScore}`;
       checkWinner();
     }, 2500);
   });

--- a/Rock Paper Scissors/src/style.css
+++ b/Rock Paper Scissors/src/style.css
@@ -68,6 +68,7 @@ body {
 }
 
 .user_score,
+.tie_score,
 .cpu_score {
   font-size: 1.2rem;
   color: #333;
@@ -79,7 +80,9 @@ body {
   left: 50%; /* Position at the center horizontally */
   transform: translateX(-210%); /* Adjust to center the score */
 }
-
+.tie_score {
+  left: 47.4%;
+}
 .cpu_score {
   right: 50%; /* Position at the center horizontally */
   transform: translateX(210%); /* Adjust to center the score */


### PR DESCRIPTION
# Description
The draw score is now displayed on the screen in the middle of user and cpu score.

Fixes:  #1944

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![Screenshot (530)](https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/143121854/5489f550-6236-4fbb-a3d3-c1febf219592)
