### PR TITLE
Now the text such as Basic mode and scientific mode is not displayed on the result.

### DIFF
--- a/Calculator/scripts/script.js
+++ b/Calculator/scripts/script.js
@@ -104,9 +104,10 @@ function handleClick(event) {
 
 // Function to display numbers and operators
 function display(num) {
-    output.value += num;
+    if(num!=='Basic Mode' && num!=='Scientific Mode'){
+        output.value += num;
+    }
 }
-
 // Function to calculate the expression
 function calculate() {
     const expression = output.value.trim();


### PR DESCRIPTION
# Description
Text is not displayed on the result part of the calculator on click of buttons such as Basic Mode and Scientific Mode.

Fixes:  #2019

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

https://github.com/Sulagna-Dutta-Roy/GGExtensions/assets/143121854/cdc0d499-bf04-4418-bcdb-5763af7656dc

